### PR TITLE
Encrypted PEM keys

### DIFF
--- a/src/bin/rage/main.rs
+++ b/src/bin/rage/main.rs
@@ -267,7 +267,18 @@ fn decrypt(opts: AgeOptions) {
         }
     } else {
         match read_keys(opts.arguments) {
-            Ok(keys) => age::Decryptor::Keys(keys),
+            Ok(keys) => {
+                // Check for unsupported keys and alert the user
+                for key in &keys {
+                    if let age::Identity::Unsupported(k) = key {
+                        eprintln!("Unsupported key: {}", "TODO: key path here");
+                        eprintln!();
+                        eprintln!("{}", k);
+                        return;
+                    }
+                }
+                age::Decryptor::Keys(keys)
+            }
             Err(e) => {
                 eprintln!("Error while reading keys: {}", e);
                 return;

--- a/src/cli_common.rs
+++ b/src/cli_common.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::PathBuf;
 
-use crate::keys::SecretKey;
+use crate::keys::Identity;
 
 /// Returns the age config directory.
 ///
@@ -28,7 +28,7 @@ pub fn get_config_dir() -> Option<PathBuf> {
 
 /// Reads keys from the provided files if given, or the default system locations
 /// if no files are given.
-pub fn read_keys(filenames: Vec<String>) -> io::Result<Vec<SecretKey>> {
+pub fn read_keys(filenames: Vec<String>) -> io::Result<Vec<Identity>> {
     let mut keys = vec![];
 
     if filenames.is_empty() {
@@ -49,11 +49,11 @@ pub fn read_keys(filenames: Vec<String>) -> io::Result<Vec<SecretKey>> {
             _ => e,
         })?;
         let buf = BufReader::new(f);
-        keys.extend(SecretKey::from_data(buf)?);
+        keys.extend(Identity::from_data(buf)?);
     } else {
         for filename in filenames {
             let buf = BufReader::new(File::open(filename)?);
-            keys.extend(SecretKey::from_data(buf)?);
+            keys.extend(Identity::from_data(buf)?);
         }
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -34,8 +34,6 @@ pub enum SecretKey {
     SshRsa(Vec<u8>, Box<rsa::RSAPrivateKey>),
     /// An ssh-ed25519 key pair.
     SshEd25519(Vec<u8>, [u8; 64]),
-    /// An encrypted OpenSSH private key.
-    EncryptedOpenSsh(EncryptedOpenSshKey),
 }
 
 impl SecretKey {
@@ -43,30 +41,6 @@ impl SecretKey {
     pub fn generate() -> Self {
         let mut rng = OsRng::new().expect("can construct OsRng");
         SecretKey::X25519(StaticSecret::new(&mut rng))
-    }
-
-    /// Parses a list of secret keys from a string.
-    pub fn from_data<R: BufRead>(mut data: R) -> io::Result<Vec<Self>> {
-        let mut buf = String::new();
-        loop {
-            match read::secret_keys(&buf) {
-                Ok((_, keys)) => {
-                    // Ensure we've found all keys in the file
-                    if data.read_line(&mut buf)? == 0 {
-                        break Ok(keys);
-                    }
-                }
-                Err(nom::Err::Incomplete(nom::Needed::Size(_))) => {
-                    data.read_line(&mut buf)?;
-                }
-                Err(_) => {
-                    break Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "invalid secret key file",
-                    ));
-                }
-            }
-        }
     }
 
     /// Serializes this secret key as a string.
@@ -79,7 +53,6 @@ impl SecretKey {
             ),
             SecretKey::SshRsa(_, _) => unimplemented!(),
             SecretKey::SshEd25519(_, _) => unimplemented!(),
-            SecretKey::EncryptedOpenSsh(_) => unimplemented!(),
         }
     }
 
@@ -89,11 +62,10 @@ impl SecretKey {
             SecretKey::X25519(sk) => RecipientKey::X25519(sk.into()),
             SecretKey::SshRsa(_, _) => unimplemented!(),
             SecretKey::SshEd25519(_, _) => unimplemented!(),
-            SecretKey::EncryptedOpenSsh(_) => unimplemented!(),
         }
     }
 
-    fn unwrap_file_key_inner(&self, line: &RecipientLine) -> Option<[u8; 16]> {
+    pub(crate) fn unwrap_file_key(&self, line: &RecipientLine) -> Option<[u8; 16]> {
         match (self, line) {
             (SecretKey::X25519(sk), RecipientLine::X25519(r)) => {
                 let pk: PublicKey = sk.into();
@@ -157,14 +129,22 @@ impl SecretKey {
             file_key
         })
     }
+}
 
+/// An encrypted secret key.
+pub enum EncryptedKey {
+    /// An encrypted OpenSSH private key.
+    OpenSsh(EncryptedOpenSshKey),
+}
+
+impl EncryptedKey {
     pub(crate) fn unwrap_file_key<P: Fn(&str) -> Option<String>>(
         &self,
         line: &RecipientLine,
         request_passphrase: P,
     ) -> Option<[u8; 16]> {
         match self {
-            SecretKey::EncryptedOpenSsh(enc) => {
+            EncryptedKey::OpenSsh(enc) => {
                 let passphrase = request_passphrase(
                     "Type passphrase for OpenSSH key (TODO: figure out how to identify which one)",
                 )?;
@@ -176,9 +156,65 @@ impl SecretKey {
                         return None;
                     }
                 };
-                decrypted.unwrap_file_key_inner(line)
+                decrypted.unwrap_file_key(line)
             }
-            _ => self.unwrap_file_key_inner(line),
+        }
+    }
+}
+
+/// An identity that has been parsed from some input.
+pub enum Identity {
+    /// An unencrypted key.
+    Unencrypted(SecretKey),
+    /// An encrypted key.
+    Encrypted(EncryptedKey),
+}
+
+impl From<SecretKey> for Identity {
+    fn from(key: SecretKey) -> Self {
+        Identity::Unencrypted(key)
+    }
+}
+
+impl From<EncryptedKey> for Identity {
+    fn from(key: EncryptedKey) -> Self {
+        Identity::Encrypted(key)
+    }
+}
+
+impl Identity {
+    /// Parses a list of secret keys from a string.
+    pub fn from_data<R: BufRead>(mut data: R) -> io::Result<Vec<Self>> {
+        let mut buf = String::new();
+        loop {
+            match read::secret_keys(&buf) {
+                Ok((_, keys)) => {
+                    // Ensure we've found all keys in the file
+                    if data.read_line(&mut buf)? == 0 {
+                        break Ok(keys);
+                    }
+                }
+                Err(nom::Err::Incomplete(nom::Needed::Size(_))) => {
+                    data.read_line(&mut buf)?;
+                }
+                Err(_) => {
+                    break Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid secret key file",
+                    ));
+                }
+            }
+        }
+    }
+
+    pub(crate) fn unwrap_file_key<P: Fn(&str) -> Option<String>>(
+        &self,
+        line: &RecipientLine,
+        request_passphrase: P,
+    ) -> Option<[u8; 16]> {
+        match self {
+            Identity::Unencrypted(key) => key.unwrap_file_key(line),
+            Identity::Encrypted(key) => key.unwrap_file_key(line, request_passphrase),
         }
     }
 }
@@ -311,18 +347,18 @@ mod read {
     use super::*;
     use crate::{openssh::ssh_secret_keys, util::read_encoded_str};
 
-    fn age_secret_key(input: &str) -> IResult<&str, SecretKey> {
+    fn age_secret_key(input: &str) -> IResult<&str, Identity> {
         preceded(
             tag(SECRET_KEY_PREFIX),
             map(read_encoded_str(32, base64::URL_SAFE_NO_PAD), |buf| {
                 let mut pk = [0; 32];
                 pk.copy_from_slice(&buf);
-                SecretKey::X25519(pk.into())
+                Identity::Unencrypted(SecretKey::X25519(pk.into()))
             }),
         )(input)
     }
 
-    fn age_secret_keys(mut input: &str) -> IResult<&str, Vec<SecretKey>> {
+    fn age_secret_keys(mut input: &str) -> IResult<&str, Vec<Identity>> {
         let mut keys = vec![];
         while !input.is_empty() {
             // Skip comments
@@ -347,13 +383,13 @@ mod read {
         Ok((input, keys))
     }
 
-    pub(super) fn secret_keys(input: &str) -> IResult<&str, Vec<SecretKey>> {
+    pub(super) fn secret_keys(input: &str) -> IResult<&str, Vec<Identity>> {
         // We try parsing the string as a single multi-line SSH key.
         // If that fails, we parse as multiple single-line age keys.
         //
         // TODO: Support "proper" PEM format, where the file is allowed to contain
         // anything before the "-----BEGIN" tag.
-        alt((ssh_secret_keys, age_secret_keys))(input)
+        alt((map(ssh_secret_keys, |key| vec![key]), age_secret_keys))(input)
     }
 
     pub(super) fn age_recipient_key(input: &str) -> IResult<&str, RecipientKey> {
@@ -372,7 +408,7 @@ mod read {
 pub(crate) mod tests {
     use std::io::BufReader;
 
-    use super::{RecipientKey, SecretKey};
+    use super::{Identity, RecipientKey};
 
     const TEST_SK: &str = "AGE_SECRET_KEY_QAvvHYA29yZk8Lelpiz8lW7QdlxkE4djb1NOjLgeUFg";
     const TEST_PK: &str = "pubkey:X4ZiZYoURuOqC2_GPISYiWbJn1-j_HECyac7BpD6kHU";
@@ -418,9 +454,13 @@ AAAEADBJvjZT8X6JRJI8xVq/1aU8nMVgOtVnmdwqWwrSlXG3sKLqeplhpW+uObz5dvMgjz
     #[test]
     fn secret_key_encoding() {
         let buf = BufReader::new(TEST_SK.as_bytes());
-        let keys = SecretKey::from_data(buf).unwrap();
+        let keys = Identity::from_data(buf).unwrap();
         assert_eq!(keys.len(), 1);
-        assert_eq!(keys[0].to_str(), TEST_SK);
+        let key = match &keys[0] {
+            Identity::Unencrypted(key) => key,
+            _ => panic!("key should be unencrypted"),
+        };
+        assert_eq!(key.to_str(), TEST_SK);
     }
 
     #[test]
@@ -432,34 +472,46 @@ AAAEADBJvjZT8X6JRJI8xVq/1aU8nMVgOtVnmdwqWwrSlXG3sKLqeplhpW+uObz5dvMgjz
     #[test]
     fn pubkey_from_secret_key() {
         let buf = BufReader::new(TEST_SK.as_bytes());
-        let keys = SecretKey::from_data(buf).unwrap();
+        let keys = Identity::from_data(buf).unwrap();
         assert_eq!(keys.len(), 1);
-        assert_eq!(keys[0].to_public().to_str(), TEST_PK);
+        let key = match &keys[0] {
+            Identity::Unencrypted(key) => key,
+            _ => panic!("key should be unencrypted"),
+        };
+        assert_eq!(key.to_public().to_str(), TEST_PK);
     }
 
     #[test]
     fn ssh_rsa_round_trip() {
         let buf = BufReader::new(TEST_SSH_RSA_SK.as_bytes());
-        let sk = SecretKey::from_data(buf).unwrap();
+        let keys = Identity::from_data(buf).unwrap();
+        let sk = match &keys[0] {
+            Identity::Unencrypted(key) => key,
+            _ => panic!("key should be unencrypted"),
+        };
         let pk: RecipientKey = TEST_SSH_RSA_PK.parse().unwrap();
 
         let file_key = [12; 16];
 
         let wrapped = pk.wrap_file_key(&file_key);
-        let unwrapped = sk[0].unwrap_file_key(&wrapped, |_| None);
+        let unwrapped = sk.unwrap_file_key(&wrapped);
         assert_eq!(unwrapped, Some(file_key));
     }
 
     #[test]
     fn ssh_ed25519_round_trip() {
         let buf = BufReader::new(TEST_SSH_ED25519_SK.as_bytes());
-        let sk = SecretKey::from_data(buf).unwrap();
+        let keys = Identity::from_data(buf).unwrap();
+        let sk = match &keys[0] {
+            Identity::Unencrypted(key) => key,
+            _ => panic!("key should be unencrypted"),
+        };
         let pk: RecipientKey = TEST_SSH_ED25519_PK.parse().unwrap();
 
         let file_key = [12; 16];
 
         let wrapped = pk.wrap_file_key(&file_key);
-        let unwrapped = sk[0].unwrap_file_key(&wrapped, |_| None);
+        let unwrapped = sk.unwrap_file_key(&wrapped);
         assert_eq!(unwrapped, Some(file_key));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!     writer.flush()?;
 //! };
 //!
-//! let decryptor = age::Decryptor::Keys(vec![key]);
+//! let decryptor = age::Decryptor::Keys(vec![key.into()]);
 //! let mut reader = decryptor.trial_decrypt(&encrypted[..], |_| None)?;
 //! let mut decrypted = vec![];
 //! reader.read_to_end(&mut decrypted);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ mod primitives;
 mod protocol;
 mod util;
 
-pub use keys::{RecipientKey, SecretKey};
+pub use keys::{Identity, RecipientKey, SecretKey};
 pub use primitives::stream::StreamReader;
 pub use protocol::{Decryptor, Encryptor};
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime};
 
 use crate::{
     format::{Header, RecipientLine},
-    keys::{RecipientKey, SecretKey},
+    keys::{Identity, RecipientKey},
     primitives::{
         aead_decrypt, aead_encrypt, hkdf, scrypt,
         stream::{Stream, StreamReader},
@@ -110,7 +110,7 @@ impl Encryptor {
 /// Handles the various types of age decryption.
 pub enum Decryptor {
     /// Trial decryption against a list of secret keys.
-    Keys(Vec<SecretKey>),
+    Keys(Vec<Identity>),
     /// Decryption with a passphrase.
     Passphrase(String),
 }
@@ -223,7 +223,7 @@ mod tests {
     use std::io::{BufReader, Read, Write};
 
     use super::{Decryptor, Encryptor};
-    use crate::keys::{RecipientKey, SecretKey};
+    use crate::keys::{Identity, RecipientKey};
 
     #[test]
     fn message_decryption() {
@@ -240,7 +240,7 @@ _vLg6QnGTU5UQSVs3cUJDmVMJ1Qj07oSXntDpsqi0Zw
 \xfbM84W\x98#\x0bj\xc8\x96\x95\xa7\x9ac\xb9\xaa-\xd5\xd0&aM\xba#H~\xbc\x97\xc8i\x1f\x14\x08\xba&4\xb2\x87\x9d\x80Sb\xed\xbe0\xda\x93\xc7\xab^o";
 
         let buf = BufReader::new(test_key.as_bytes());
-        let d = Decryptor::Keys(SecretKey::from_data(buf).unwrap());
+        let d = Decryptor::Keys(Identity::from_data(buf).unwrap());
         let mut r1 = d.trial_decrypt(&test_msg_1[..], |_| None).unwrap();
         let mut r2 = d.trial_decrypt(&test_msg_2[..], |_| None).unwrap();
 
@@ -256,7 +256,7 @@ _vLg6QnGTU5UQSVs3cUJDmVMJ1Qj07oSXntDpsqi0Zw
     #[test]
     fn ssh_rsa_round_trip() {
         let buf = BufReader::new(crate::keys::tests::TEST_SSH_RSA_SK.as_bytes());
-        let sk = SecretKey::from_data(buf).unwrap();
+        let sk = Identity::from_data(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_SSH_RSA_PK.parse().unwrap();
 
         let test_msg = b"This is a test message. For testing.";
@@ -280,7 +280,7 @@ _vLg6QnGTU5UQSVs3cUJDmVMJ1Qj07oSXntDpsqi0Zw
     #[test]
     fn ssh_ed25519_round_trip() {
         let buf = BufReader::new(crate::keys::tests::TEST_SSH_ED25519_SK.as_bytes());
-        let sk = SecretKey::from_data(buf).unwrap();
+        let sk = Identity::from_data(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_SSH_ED25519_PK.parse().unwrap();
 
         let test_msg = b"This is a test message. For testing.";


### PR DESCRIPTION
We parse them in order to detect them, and then immediately reject them as unsupported, with a helpful message to inform users how to migrate away.