### PR TITLE
YubiKey plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "age-core",
  "bech32",
  "chrono",
+ "secrecy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "age-core",
  "bech32",
  "chrono",
+ "gumdrop",
  "secrecy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,18 @@ dependencies = [
 [[package]]
 name = "age-plugin-yubikey"
 version = "0.0.0"
+dependencies = [
+ "age-core",
+ "age-plugin",
+ "base64 0.12.3",
+ "bech32",
+ "elliptic-curve",
+ "gumdrop",
+ "p256",
+ "ring",
+ "secrecy",
+ "sha2",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -688,6 +700,17 @@ name = "either"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1237,6 +1260,15 @@ name = "os_str_bytes"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
+
+[[package]]
+name = "p256"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f8aff5e98a6a83e374418a0a510ae4d9d45d714b5b0767c2e23ea007d0ba54"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "age-plugin"
+version = "0.0.0"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "secrecy",
  "sha2",
  "subtle",
+ "which",
  "x25519-dalek",
  "zeroize",
 ]
@@ -141,6 +142,7 @@ dependencies = [
 name = "age-plugin"
 version = "0.0.0"
 dependencies = [
+ "age-core",
  "bech32",
  "chrono",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "block-modes",
  "c2-chacha",
  "chacha20poly1305",
- "console",
+ "console 0.12.0",
  "cookie-factory",
  "criterion",
  "criterion-cycles-per-byte",
@@ -157,9 +157,13 @@ dependencies = [
  "age-plugin",
  "base64 0.12.3",
  "bech32",
+ "chrono",
+ "dialoguer",
  "elliptic-curve",
  "gumdrop",
+ "hex",
  "p256",
+ "rand",
  "ring",
  "secrecy",
  "sha2",
@@ -469,6 +473,23 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "termios",
+ "unicode-width",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "console"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
@@ -708,6 +729,17 @@ dependencies = [
  "block-cipher 0.8.0",
  "byteorder",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
+dependencies = [
+ "console 0.11.3",
+ "lazy_static",
+ "tempfile",
 ]
 
 [[package]]
@@ -1017,6 +1049,12 @@ checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hkdf"
@@ -1557,7 +1595,7 @@ dependencies = [
  "chrono",
  "clap 3.0.0-beta.1",
  "clap_generate",
- "console",
+ "console 0.12.0",
  "env_logger",
  "flate2",
  "fuse_mt",
@@ -1682,6 +1720,15 @@ name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ring"
@@ -2039,6 +2086,20 @@ dependencies = [
  "libc",
  "redox_syscall",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "ring",
  "secrecy",
  "sha2",
+ "yubikey-piv",
 ]
 
 [[package]]
@@ -664,6 +665,49 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+
+[[package]]
+name = "der-oid-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66558629d772c3be040566b7be07be8c8f5aecee95e4a092dfe2efc313277ad"
+dependencies = [
+ "nom",
+ "num-bigint 0.3.0",
+ "num-traits",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "der-parser"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97e68dc033b340ff19244dd3caa94c6148383711361d5e3c74f64175760a93c"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint 0.3.0",
+ "num-traits",
+ "proc-macro-hack",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "des"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e084b5048dec677e6c9f27d7abc551dde7d127cf4127fea82323c98a30d7fa0d"
+dependencies = [
+ "block-cipher 0.8.0",
+ "byteorder",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1173,6 +1217,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,12 +1326,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a21dedbfa7a0603d7c9429b8b427edc4a113c3741e31610ba4a3cbfebe0ff08"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170d73bf11f39b4ce1809aabc95bf5c33564cdc16fc3200ddda17a5f6e5e48b"
 dependencies = [
+ "base64 0.12.3",
  "crypto-mac 0.9.1",
+ "hmac 0.9.0",
+ "rand",
+ "rand_core",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e09a8d8705a2c9b1ffe1f9dd9580efe3f8e80c19fc9f99038fe99b7bb56c83"
+dependencies = [
+ "bitflags",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b7bfecba2c0f1b5efb0e7caf7533ab1c295024165bcbb066231f60d33e23ea"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -1669,6 +1758,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a9050636e8a1b487ba1fbe99114021cd7594dde3ce6ed95bfc1691e5b5367b"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1777,17 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1786,6 +1895,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,7 +1927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
 ]
 
@@ -1863,6 +1985,15 @@ name = "subtle"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+
+[[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "syn"
@@ -2223,12 +2354,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9335b8ff50b6a0de184b3eeb11fdce74224e3af90ca7265012512e73fc999d1a"
+dependencies = [
+ "chrono",
+ "cookie-factory",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.8.0-beta4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585710d3abbfc2f12099e0e1bfd7f715a84e9374c9113a63ca4b02d8c20fd322"
+dependencies = [
+ "base64 0.12.3",
+ "chrono",
+ "data-encoding",
+ "der-oid-macro",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "num-bigint 0.3.0",
+ "rusticata-macros",
+ "rustversion",
+]
+
+[[package]]
 name = "xattr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yubikey-piv"
+version = "0.0.3"
+source = "git+https://github.com/str4d/yubikey-piv.rs.git?branch=update-deps#c39697149690d9b905ad77d6fe1218532ec22948"
+dependencies = [
+ "chrono",
+ "cookie-factory",
+ "der-parser",
+ "des",
+ "elliptic-curve",
+ "getrandom",
+ "hmac 0.9.0",
+ "log 0.4.11",
+ "nom",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "p384",
+ "pbkdf2",
+ "pcsc",
+ "rsa",
+ "secrecy",
+ "sha-1",
+ "sha2",
+ "subtle",
+ "subtle-encoding",
+ "x509",
+ "x509-parser",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "age-plugin-yubikey"
+version = "0.0.0"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,10 @@ dependencies = [
 [[package]]
 name = "age-plugin"
 version = "0.0.0"
+dependencies = [
+ "bech32",
+ "chrono",
+]
 
 [[package]]
 name = "aho-corasick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "age",
     "age-core",
+    "age-plugin",
     "rage",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "age",
     "age-core",
     "age-plugin",
+    "age-plugin-yubikey",
     "rage",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "age-plugin-yubikey",
     "rage",
 ]
+
+[patch.crates-io]
+yubikey-piv = { git = "https://github.com/str4d/yubikey-piv.rs.git", branch = "update-deps" }

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -33,3 +33,6 @@ nom = "5"
 
 # Secret management
 secrecy = "0.7"
+
+[features]
+plugin = []

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -37,7 +37,7 @@ pub struct AgeStanza<'a> {
 /// recipient.
 ///
 /// This is the owned type; see [`AgeStanza`] for the reference type.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Stanza {
     /// A tag identifying this stanza type.
     pub tag: String,

--- a/age-core/src/lib.rs
+++ b/age-core/src/lib.rs
@@ -4,3 +4,6 @@
 
 pub mod format;
 pub mod primitives;
+
+#[cfg(feature = "plugin")]
+pub mod plugin;

--- a/age-core/src/plugin.rs
+++ b/age-core/src/plugin.rs
@@ -1,0 +1,374 @@
+use rand::{thread_rng, Rng};
+use secrecy::Zeroize;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::iter;
+use std::path::Path;
+use std::process::{ChildStdin, ChildStdout, Command, Stdio};
+
+use crate::format::{grease_the_joint, read, write, Stanza};
+
+const COMMAND_DONE: &str = "done";
+const RESPONSE_OK: &str = "ok";
+const RESPONSE_FAIL: &str = "fail";
+const RESPONSE_UNSUPPORTED: &str = "unsupported";
+
+/// Result type for the plugin protocol.
+///
+/// - The outer error indicates a problem with the IPC transport or state machine; these
+///   should result in the state machine being terminated and the connection closed.
+/// - The inner error indicates an error within the plugin protocol, that the recipient
+///   should explicitly handle.
+pub type Result<T, E> = io::Result<std::result::Result<T, E>>;
+
+/// A connection to a plugin binary.
+pub struct Connection<R: Read, W: Write> {
+    input: BufReader<R>,
+    output: W,
+    buffer: String,
+}
+
+impl Connection<ChildStdout, ChildStdin> {
+    /// Start a plugin binary with the given state machine.
+    pub fn open(binary: &Path, state_machine: &str) -> io::Result<Self> {
+        let process = Command::new(binary)
+            .arg(state_machine)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+        let input = BufReader::new(process.stdout.expect("could open stdout"));
+        let output = process.stdin.expect("could open stdin");
+        Ok(Connection {
+            input,
+            output,
+            buffer: String::new(),
+        })
+    }
+}
+
+impl Connection<io::Stdin, io::Stdout> {
+    /// Initialise a connection from an age client.
+    pub fn accept() -> Self {
+        Connection {
+            input: BufReader::new(io::stdin()),
+            output: io::stdout(),
+            buffer: String::new(),
+        }
+    }
+}
+
+impl<R: Read, W: Write> Connection<R, W> {
+    fn send<S: AsRef<str>>(
+        &mut self,
+        command: &str,
+        metadata: &[S],
+        data: &[u8],
+    ) -> io::Result<()> {
+        use cookie_factory::{combinator::string, sequence::pair};
+
+        cookie_factory::gen_simple(
+            pair(write::age_stanza(command, metadata, data), string("\n\n")),
+            &mut self.output,
+        )
+        .expect("TODO: errors")
+        .flush()
+    }
+
+    fn send_stanza<S: AsRef<str>>(
+        &mut self,
+        command: &str,
+        metadata: &[S],
+        stanza: &Stanza,
+    ) -> io::Result<()> {
+        let metadata: Vec<_> = metadata
+            .iter()
+            .map(|s| s.as_ref())
+            .chain(iter::once(stanza.tag.as_str()))
+            .chain(stanza.args.iter().map(|s| s.as_str()))
+            .collect();
+
+        self.send(command, &metadata, &stanza.body)
+    }
+
+    fn receive(&mut self) -> io::Result<Stanza> {
+        use nom::{
+            character::streaming::newline,
+            sequence::{pair, terminated},
+            IResult,
+        };
+
+        fn stanza<'a>(input: &'a [u8]) -> IResult<&'a [u8], crate::format::AgeStanza<'a>> {
+            terminated(read::age_stanza, pair(newline, newline))(input)
+        }
+
+        // We are finished with any prior response.
+        self.buffer.zeroize();
+        self.buffer.clear();
+
+        loop {
+            match stanza(self.buffer.as_bytes()) {
+                Ok((_, r)) => break Ok(r.into()),
+                Err(nom::Err::Incomplete(_)) => {
+                    if self.input.read_line(&mut self.buffer)? == 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "incomplete response",
+                        ));
+                    };
+                }
+                Err(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid response",
+                    ));
+                }
+            }
+        }
+    }
+
+    fn grease_gun(&mut self) -> impl Iterator<Item = Option<Stanza>> {
+        // Add 5% grease
+        let mut rng = thread_rng();
+        (0..2).map(move |_| {
+            if rng.gen_range(0, 100) < 5 {
+                Some(grease_the_joint())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn done(&mut self) -> io::Result<()> {
+        self.send::<&str>(COMMAND_DONE, &[], &[])
+    }
+
+    /// Run a unidirectional phase as the controller.
+    pub fn unidir_send<P: FnOnce(UnidirSend<R, W>) -> io::Result<()>>(
+        &mut self,
+        phase_steps: P,
+    ) -> io::Result<()> {
+        phase_steps(UnidirSend(self))?;
+        for grease in self.grease_gun().filter_map(|g| g) {
+            self.send(&grease.tag, &grease.args, &grease.body)?;
+        }
+        self.done()
+    }
+
+    /// Run a unidirectional phase as the recipient.
+    pub fn unidir_receive(&mut self) -> io::Result<Vec<Stanza>> {
+        let mut stanzas = vec![];
+        loop {
+            let stanza = self.receive()?;
+            if stanza.tag == COMMAND_DONE {
+                break Ok(stanzas);
+            }
+            stanzas.push(stanza);
+        }
+    }
+
+    /// Run a bidirectional phase as the controller.
+    pub fn bidir_send<P: FnOnce(BidirSend<R, W>) -> io::Result<()>>(
+        &mut self,
+        phase_steps: P,
+    ) -> io::Result<()> {
+        phase_steps(BidirSend(self))?;
+        for grease in self.grease_gun().filter_map(|g| g) {
+            self.send(&grease.tag, &grease.args, &grease.body)?;
+            self.receive()?;
+        }
+        self.done()
+    }
+
+    /// Run a bidirectional phase as the recipient.
+    pub fn bidir_receive<H>(&mut self, mut handler: H) -> io::Result<()>
+    where
+        H: FnMut(Stanza, Reply<R, W>) -> Response,
+    {
+        loop {
+            let stanza = self.receive()?;
+            if stanza.tag == COMMAND_DONE {
+                break Ok(());
+            }
+            handler(stanza, Reply(self)).0?;
+        }
+    }
+}
+
+/// Actions that a controller may take during a unidirectional phase.
+///
+/// Grease is applied automatically.
+pub struct UnidirSend<'a, R: Read, W: Write>(&'a mut Connection<R, W>);
+
+impl<'a, R: Read, W: Write> UnidirSend<'a, R, W> {
+    /// Send a command.
+    pub fn send(&mut self, command: &str, metadata: &[&str], data: &[u8]) -> io::Result<()> {
+        for grease in self.0.grease_gun().filter_map(|g| g) {
+            self.0.send(&grease.tag, &grease.args, &grease.body)?;
+        }
+        self.0.send(command, metadata, data)
+    }
+
+    /// Send an entire stanza.
+    pub fn send_stanza(
+        &mut self,
+        command: &str,
+        metadata: &[&str],
+        stanza: &Stanza,
+    ) -> io::Result<()> {
+        for grease in self.0.grease_gun().filter_map(|g| g) {
+            self.0.send(&grease.tag, &grease.args, &grease.body)?;
+        }
+        self.0.send_stanza(command, metadata, stanza)
+    }
+}
+
+/// Actions that a controller may take during a bidirectional phase.
+///
+/// Grease is applied automatically.
+pub struct BidirSend<'a, R: Read, W: Write>(&'a mut Connection<R, W>);
+
+impl<'a, R: Read, W: Write> BidirSend<'a, R, W> {
+    /// Send a command and receive a response.
+    pub fn send(&mut self, command: &str, metadata: &[&str], data: &[u8]) -> Result<Stanza, ()> {
+        for grease in self.0.grease_gun().filter_map(|g| g) {
+            self.0.send(&grease.tag, &grease.args, &grease.body)?;
+            self.0.receive()?;
+        }
+        self.0.send(command, metadata, data)?;
+        let s = self.0.receive()?;
+        match s.tag.as_ref() {
+            RESPONSE_OK => Ok(Ok(s)),
+            RESPONSE_FAIL => Ok(Err(())),
+            tag => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected response: {}", tag),
+            )),
+        }
+    }
+}
+
+/// The possible replies to a bidirectional command.
+pub struct Reply<'a, R: Read, W: Write>(&'a mut Connection<R, W>);
+
+impl<'a, R: Read, W: Write> Reply<'a, R, W> {
+    /// Reply with `ok` and optional data.
+    pub fn ok(self, data: Option<&[u8]>) -> Response {
+        Response(
+            self.0
+                .send::<&str>(RESPONSE_OK, &[], data.unwrap_or_default()),
+        )
+    }
+
+    /// The command failed (for example, the user failed to respond to an input request).
+    pub fn fail(self) -> Response {
+        Response(self.0.send::<&str>(RESPONSE_FAIL, &[], &[]))
+    }
+
+    /// The command is unknown to us.
+    pub fn unsupported(self) -> Response {
+        Response(self.0.send::<&str>(RESPONSE_UNSUPPORTED, &[], &[]))
+    }
+}
+
+/// A response to a bidirectional command.
+pub struct Response(io::Result<()>);
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    pub struct Pipe(Vec<u8>);
+
+    impl Pipe {
+        pub fn new() -> Arc<Mutex<Self>> {
+            Arc::new(Mutex::new(Pipe(Vec::new())))
+        }
+    }
+
+    pub struct PipeReader {
+        pipe: Arc<Mutex<Pipe>>,
+    }
+
+    impl PipeReader {
+        pub fn new(pipe: Arc<Mutex<Pipe>>) -> Self {
+            PipeReader { pipe }
+        }
+    }
+
+    impl Read for PipeReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let mut pipe = self.pipe.lock().unwrap();
+            let n_in = pipe.0.len();
+            let n_out = buf.len();
+            if n_in == 0 {
+                Err(io::Error::new(io::ErrorKind::WouldBlock, ""))
+            } else if n_out < n_in {
+                buf.copy_from_slice(&pipe.0[..n_out]);
+                pipe.0 = pipe.0.split_off(n_out);
+                Ok(n_out)
+            } else {
+                (&mut buf[..n_in]).copy_from_slice(&pipe.0);
+                pipe.0.clear();
+                Ok(n_in)
+            }
+        }
+    }
+
+    pub struct PipeWriter {
+        pipe: Arc<Mutex<Pipe>>,
+    }
+
+    impl PipeWriter {
+        pub fn new(pipe: Arc<Mutex<Pipe>>) -> Self {
+            PipeWriter { pipe }
+        }
+    }
+
+    impl Write for PipeWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut pipe = self.pipe.lock().unwrap();
+            pipe.0.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn mock_plugin() {
+        let client_to_plugin = Pipe::new();
+        let plugin_to_client = Pipe::new();
+
+        let mut client_conn = Connection {
+            input: BufReader::new(PipeReader::new(plugin_to_client.clone())),
+            output: PipeWriter::new(client_to_plugin.clone()),
+            buffer: String::new(),
+        };
+        let mut plugin_conn = Connection {
+            input: BufReader::new(PipeReader::new(client_to_plugin.clone())),
+            output: PipeWriter::new(plugin_to_client.clone()),
+            buffer: String::new(),
+        };
+
+        client_conn
+            .unidir_send(|mut phase| phase.send("test", &["foo"], b"bar"))
+            .unwrap();
+        let stanza = plugin_conn
+            .unidir_receive()
+            .unwrap()
+            .into_iter()
+            .find(|s| s.tag == "test")
+            .unwrap();
+        assert_eq!(
+            stanza,
+            Stanza {
+                tag: "test".to_owned(),
+                args: vec!["foo".to_owned()],
+                body: b"bar"[..].to_owned()
+            }
+        );
+    }
+}

--- a/age-plugin-yubikey/Cargo.toml
+++ b/age-plugin-yubikey/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "age-plugin-yubikey"
+description = "[BETA] YubiKey plugin for age."
+version = "0.0.0"
+authors = ["Jack Grigg <thestr4d@gmail.com>"]
+repository = "https://github.com/str4d/rage"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]

--- a/age-plugin-yubikey/Cargo.toml
+++ b/age-plugin-yubikey/Cargo.toml
@@ -18,3 +18,4 @@ p256 = "0.4"
 ring = "0.16.15"
 secrecy = "0.7"
 sha2 = "0.9"
+yubikey-piv = { version = "0.0.3", features = ["untested"] }

--- a/age-plugin-yubikey/Cargo.toml
+++ b/age-plugin-yubikey/Cargo.toml
@@ -8,3 +8,13 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+age-core = { version = "0.4.0", path = "../age-core" }
+age-plugin = { version = "0.0.0", path = "../age-plugin" }
+base64 = "0.12"
+bech32 = "0.7"
+elliptic-curve = "0.5"
+gumdrop = "0.8"
+p256 = "0.4"
+ring = "0.16.15"
+secrecy = "0.7"
+sha2 = "0.9"

--- a/age-plugin-yubikey/Cargo.toml
+++ b/age-plugin-yubikey/Cargo.toml
@@ -12,9 +12,13 @@ age-core = { version = "0.4.0", path = "../age-core" }
 age-plugin = { version = "0.0.0", path = "../age-plugin" }
 base64 = "0.12"
 bech32 = "0.7"
+chrono = "0.4"
+dialoguer = "0.6"
 elliptic-curve = "0.5"
 gumdrop = "0.8"
+hex = "0.4"
 p256 = "0.4"
+rand = "0.7"
 ring = "0.16.15"
 secrecy = "0.7"
 sha2 = "0.9"

--- a/age-plugin-yubikey/src/format.rs
+++ b/age-plugin-yubikey/src/format.rs
@@ -1,0 +1,83 @@
+use age_core::{
+    format::{FileKey, Stanza},
+    primitives::{aead_encrypt, hkdf},
+};
+use bech32::ToBase32;
+use ring::{
+    agreement::{agree_ephemeral, EphemeralPrivateKey, UnparsedPublicKey, ECDH_P256},
+    rand::SystemRandom,
+};
+use secrecy::ExposeSecret;
+use sha2::{Digest, Sha256};
+use std::convert::TryInto;
+
+use crate::{p256::PublicKey, RECIPIENT_PREFIX, RECIPIENT_TAG};
+
+const RECIPIENT_KEY_LABEL: &[u8] = b"age-encryption.org/v1/yubikey";
+
+const TAG_BYTES: usize = 4;
+const ENCRYPTED_FILE_KEY_BYTES: usize = 32;
+
+pub(crate) fn piv_to_str(pk: &PublicKey) -> String {
+    bech32::encode(RECIPIENT_PREFIX, pk.as_bytes().to_base32()).expect("HRP is valid")
+}
+
+pub(crate) fn piv_tag(pk: &PublicKey) -> [u8; TAG_BYTES] {
+    let tag = Sha256::digest(piv_to_str(pk).as_bytes());
+    (&tag[0..TAG_BYTES]).try_into().expect("length is correct")
+}
+
+#[derive(Debug)]
+pub(crate) struct RecipientLine {
+    tag: [u8; TAG_BYTES],
+    epk: PublicKey,
+    encrypted_file_key: [u8; ENCRYPTED_FILE_KEY_BYTES],
+}
+
+impl From<RecipientLine> for Stanza {
+    fn from(r: RecipientLine) -> Self {
+        Stanza {
+            tag: RECIPIENT_TAG.to_owned(),
+            args: vec![
+                base64::encode_config(&r.tag, base64::STANDARD_NO_PAD),
+                base64::encode_config(r.epk.as_bytes(), base64::STANDARD_NO_PAD),
+            ],
+            body: r.encrypted_file_key.to_vec(),
+        }
+    }
+}
+
+impl RecipientLine {
+    pub(crate) fn wrap_file_key(file_key: &FileKey, pk: &PublicKey) -> Self {
+        let rng = SystemRandom::new();
+
+        let esk = EphemeralPrivateKey::generate(&ECDH_P256, &rng).expect("TODO handle failing RNG");
+        let epk = PublicKey::from_bytes(esk.compute_public_key().expect("TODO").as_ref())
+            .expect("epk is valid");
+
+        let pk_uncompressed = pk.decompress();
+        let pk_ring = UnparsedPublicKey::new(&ECDH_P256, pk_uncompressed.as_bytes());
+
+        let enc_key = agree_ephemeral(esk, &pk_ring, (), |shared_secret| {
+            let mut salt = vec![];
+            salt.extend_from_slice(epk.as_bytes());
+            salt.extend_from_slice(pk.as_bytes());
+
+            Ok(hkdf(&salt, RECIPIENT_KEY_LABEL, shared_secret))
+        })
+        .expect("keys are correct");
+
+        let encrypted_file_key = {
+            let mut key = [0; ENCRYPTED_FILE_KEY_BYTES];
+            key.copy_from_slice(&aead_encrypt(&enc_key, file_key.expose_secret()));
+            key
+        };
+
+        RecipientLine {
+            tag: piv_tag(pk),
+            epk,
+            encrypted_file_key,
+        }
+        .into()
+    }
+}

--- a/age-plugin-yubikey/src/main.rs
+++ b/age-plugin-yubikey/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/age-plugin-yubikey/src/main.rs
+++ b/age-plugin-yubikey/src/main.rs
@@ -1,6 +1,16 @@
 use age_plugin::{identity, recipient};
+use dialoguer::{Confirm, Password, Select};
 use gumdrop::Options;
+use rand::{rngs::OsRng, RngCore};
+use std::convert::TryFrom;
+use std::fmt;
 use std::io;
+use yubikey_piv::{
+    certificate::{Certificate, PublicKeyInfo},
+    key::{generate as yubikey_generate, AlgorithmId, Key, RetiredSlotId, SlotId},
+    policy::{PinPolicy, TouchPolicy},
+    MgmKey, YubiKey,
+};
 
 mod format;
 mod p256;
@@ -10,6 +20,77 @@ mod yubikey;
 const IDENTITY_PREFIX: &str = "age-plugin-yubikey-";
 const RECIPIENT_PREFIX: &str = "age1yubikey";
 const RECIPIENT_TAG: &str = "yubikey";
+
+const USABLE_SLOTS: [RetiredSlotId; 20] = [
+    RetiredSlotId::R1,
+    RetiredSlotId::R2,
+    RetiredSlotId::R3,
+    RetiredSlotId::R4,
+    RetiredSlotId::R5,
+    RetiredSlotId::R6,
+    RetiredSlotId::R7,
+    RetiredSlotId::R8,
+    RetiredSlotId::R9,
+    RetiredSlotId::R10,
+    RetiredSlotId::R11,
+    RetiredSlotId::R12,
+    RetiredSlotId::R13,
+    RetiredSlotId::R14,
+    RetiredSlotId::R15,
+    RetiredSlotId::R16,
+    RetiredSlotId::R17,
+    RetiredSlotId::R18,
+    RetiredSlotId::R19,
+    RetiredSlotId::R20,
+];
+
+enum Error {
+    Io(io::Error),
+    YubiKey(yubikey_piv::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<yubikey_piv::error::Error> for Error {
+    fn from(e: yubikey_piv::error::Error) -> Self {
+        Error::YubiKey(e)
+    }
+}
+
+// Rust only supports `fn main() -> Result<(), E: Debug>`, so we implement `Debug`
+// manually to provide the error output we want.
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Io(e) => writeln!(f, "Failed to set up YubiKey: {}", e)?,
+            Error::YubiKey(e) => match e {
+                yubikey_piv::error::Error::NotFound => {
+                    writeln!(f, "Please insert the YubiKey you want to set up")?
+                }
+                e => {
+                    writeln!(f, "Error while communicating with YubiKey: {}", e)?;
+                    use std::error::Error;
+                    if let Some(inner) = e.source() {
+                        writeln!(f, "Cause: {}", inner)?;
+                    }
+                }
+            },
+        }
+        writeln!(f)?;
+        writeln!(
+            f,
+            "[ Did this not do what you expected? Could an error be more useful? ]"
+        )?;
+        write!(
+            f,
+            "[ Tell us: https://str4d.xyz/rage/report                            ]"
+        )
+    }
+}
 
 #[derive(Debug, Options)]
 struct PluginOptions {
@@ -23,15 +104,189 @@ struct PluginOptions {
     identity_plugin_v1: bool,
 }
 
-fn main() -> io::Result<()> {
+fn main() -> Result<(), Error> {
     let opts = PluginOptions::parse_args_default_or_exit();
 
     if opts.recipient_plugin_v1 {
-        recipient::run_v1(plugin::RecipientPlugin::default())
+        return recipient::run_v1(plugin::RecipientPlugin::default()).map_err(Error::from);
     } else if opts.identity_plugin_v1 {
-        identity::run_v1(plugin::IdentityPlugin::default())
-    } else {
-        // TODO: Key generation
-        Ok(())
+        return identity::run_v1(plugin::IdentityPlugin::default()).map_err(Error::from);
     }
+
+    let mut yubikey = YubiKey::open()?;
+    let keys = Key::list(&mut yubikey)?;
+
+    let slots: Vec<_> = USABLE_SLOTS
+        .iter()
+        .enumerate()
+        .map(|(i, slot)| {
+            // Use 1-indexing in the UI for niceness
+            let i = i + 1;
+
+            let occupied = keys.iter().find(|key| key.slot() == SlotId::Retired(*slot));
+            if let Some(key) = occupied {
+                format!(
+                    "Slot {} ({}, Algorithm: {:?})",
+                    i,
+                    key.certificate().subject(),
+                    key.certificate().subject_pki().algorithm(),
+                )
+            } else {
+                format!("Slot {} (Empty)", i)
+            }
+        })
+        .collect();
+
+    let (created, (stub, recipient)) = loop {
+        let (slot_index, slot) = match Select::new()
+            .with_prompt("Use the up/down arrow keys to select a PIV slot (q to quit)")
+            .items(&slots)
+            .default(0)
+            .interact_opt()?
+        {
+            Some(slot) => (slot + 1, USABLE_SLOTS[slot]),
+            None => return Ok(()),
+        };
+
+        if let Some(key) = keys.iter().find(|key| key.slot() == SlotId::Retired(slot)) {
+            match key.certificate().subject_pki() {
+                PublicKeyInfo::EcP256(pubkey) => {
+                    if Confirm::new()
+                        .with_prompt(&format!("Use existing key in slot {}?", slot_index))
+                        .interact()?
+                    {
+                        break (
+                            // TODO: enable replacing this with
+                            // key.certificate().created(),
+                            chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                            yubikey::Stub::new(yubikey.serial(), slot, pubkey)
+                                .expect("YubiKey only stores valid pubkeys"),
+                        );
+                    }
+                }
+                PublicKeyInfo::Rsa { .. } | PublicKeyInfo::EcP384(_) => {
+                    // TODO: Don't allow this to be selected, by detecting existing keys correctly
+                    eprintln!("Error: age requires P-256 for YubiKeys.");
+                    return Ok(());
+                }
+            }
+        } else {
+            let pin_policy = match Select::new()
+                .with_prompt("Select a PIN policy")
+                .items(&[
+                    "Always (A PIN is required for every decryption, if set)",
+                    "Once   (A PIN is required once per session, if set)",
+                    "Never  (A PIN is NOT required to decrypt)",
+                ])
+                .default(1)
+                .interact_opt()?
+            {
+                Some(0) => PinPolicy::Always,
+                Some(1) => PinPolicy::Once,
+                Some(2) => PinPolicy::Never,
+                Some(_) => unreachable!(),
+                None => return Ok(()),
+            };
+
+            let touch_policy = match Select::new()
+                .with_prompt("Select a touch policy")
+                .items(&[
+                    "Always (A physical touch is required for every decryption),",
+                    "Cached (A physical touch is required for decryption, and is cached for 15 seconds)",
+                    "Never  (A physical touch is NOT required to decrypt)",
+                ])
+                .default(0)
+                .interact_opt()?
+            {
+                Some(0) => TouchPolicy::Always,
+                Some(1) => TouchPolicy::Cached,
+                Some(2) => TouchPolicy::Never,
+                Some(_) => unreachable!(),
+                None => return Ok(()),
+            };
+
+            if Confirm::new()
+                .with_prompt(&format!("Generate new key in slot {}?", slot_index))
+                .interact()?
+            {
+                let mgm_input = Password::new()
+                    .with_prompt("Enter the management key [blank to use default key]")
+                    .allow_empty_password(true)
+                    .interact()?;
+                yubikey.authenticate(if mgm_input.is_empty() {
+                    MgmKey::default()
+                } else {
+                    match hex::decode(mgm_input) {
+                        Ok(mgm_bytes) => match MgmKey::try_from(&mgm_bytes[..]) {
+                            Ok(mgm_key) => mgm_key,
+                            Err(_) => {
+                                eprintln!("Incorrect management key size");
+                                return Ok(());
+                            }
+                        },
+                        Err(_) => {
+                            eprintln!("Management key must be a hex string");
+                            return Ok(());
+                        }
+                    }
+                })?;
+
+                if let PinPolicy::Never = pin_policy {
+                    // No need to enter PIN
+                } else {
+                    let pin = Password::new()
+                        .with_prompt(&format!(
+                            "Enter PIN for YubiKey with serial {}",
+                            yubikey.serial()
+                        ))
+                        .interact()?;
+                    yubikey.verify_pin(pin.as_bytes())?;
+                }
+
+                if let TouchPolicy::Never = touch_policy {
+                    // No need to touch YubiKey
+                } else {
+                    eprintln!("Please touch the YubiKey");
+                }
+
+                // Generate a new key in the selected slot.
+                let generated = yubikey_generate(
+                    &mut yubikey,
+                    SlotId::Retired(slot),
+                    AlgorithmId::EccP256,
+                    pin_policy,
+                    touch_policy,
+                )?;
+
+                let mut serial = [0; 20];
+                OsRng.fill_bytes(&mut serial);
+
+                let cert = Certificate::generate_self_signed(
+                    &mut yubikey,
+                    SlotId::Retired(slot),
+                    serial,
+                    None,
+                    "rage-keygen".to_owned(),
+                    generated,
+                )?;
+
+                match cert.subject_pki() {
+                    PublicKeyInfo::EcP256(pubkey) => {
+                        break (
+                            chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                            yubikey::Stub::new(yubikey.serial(), slot, pubkey)
+                                .expect("YubiKey generates a valid pubkey"),
+                        );
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+
+    println!("# created: {}", created);
+    println!("# public key: {}", format::piv_to_str(&recipient));
+    println!("{}", stub.to_str());
+
+    Ok(())
 }

--- a/age-plugin-yubikey/src/main.rs
+++ b/age-plugin-yubikey/src/main.rs
@@ -1,11 +1,13 @@
-use age_plugin::recipient;
+use age_plugin::{identity, recipient};
 use gumdrop::Options;
 use std::io;
 
 mod format;
 mod p256;
 mod plugin;
+mod yubikey;
 
+const IDENTITY_PREFIX: &str = "age-plugin-yubikey-";
 const RECIPIENT_PREFIX: &str = "age1yubikey";
 const RECIPIENT_TAG: &str = "yubikey";
 
@@ -16,6 +18,9 @@ struct PluginOptions {
 
     #[options(help = "run as an age recipient plugin", no_short)]
     recipient_plugin_v1: bool,
+
+    #[options(help = "run as an age identity plugin", no_short)]
+    identity_plugin_v1: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -23,6 +28,8 @@ fn main() -> io::Result<()> {
 
     if opts.recipient_plugin_v1 {
         recipient::run_v1(plugin::RecipientPlugin::default())
+    } else if opts.identity_plugin_v1 {
+        identity::run_v1(plugin::IdentityPlugin::default())
     } else {
         // TODO: Key generation
         Ok(())

--- a/age-plugin-yubikey/src/main.rs
+++ b/age-plugin-yubikey/src/main.rs
@@ -1,3 +1,30 @@
-fn main() {
-    println!("Hello, world!");
+use age_plugin::recipient;
+use gumdrop::Options;
+use std::io;
+
+mod format;
+mod p256;
+mod plugin;
+
+const RECIPIENT_PREFIX: &str = "age1yubikey";
+const RECIPIENT_TAG: &str = "yubikey";
+
+#[derive(Debug, Options)]
+struct PluginOptions {
+    #[options(help = "print help message")]
+    help: bool,
+
+    #[options(help = "run as an age recipient plugin", no_short)]
+    recipient_plugin_v1: bool,
+}
+
+fn main() -> io::Result<()> {
+    let opts = PluginOptions::parse_args_default_or_exit();
+
+    if opts.recipient_plugin_v1 {
+        recipient::run_v1(plugin::RecipientPlugin::default())
+    } else {
+        // TODO: Key generation
+        Ok(())
+    }
 }

--- a/age-plugin-yubikey/src/p256.rs
+++ b/age-plugin-yubikey/src/p256.rs
@@ -1,0 +1,46 @@
+use elliptic_curve::weierstrass::{
+    public_key::FromPublicKey, CompressedPoint, PublicKey as EcPublicKey, UncompressedPoint,
+};
+use p256::{AffinePoint, NistP256};
+use std::fmt;
+
+/// Wrapper around a compressed secp256r1 curve point.
+#[derive(Clone)]
+pub struct PublicKey(CompressedPoint<NistP256>);
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PublicKey({:?})", self.as_bytes())
+    }
+}
+
+impl PublicKey {
+    /// Attempts to parse a valid secp256r1 public key from a byte slice.
+    ///
+    /// The slice must contain an SEC-1-encoded public key.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        Self::from_pubkey(&EcPublicKey::from_bytes(bytes)?)
+    }
+
+    /// Attempts to parse a valid secp256r1 public key from its SEC-1 encoding.
+    pub(crate) fn from_pubkey(pubkey: &EcPublicKey<NistP256>) -> Option<Self> {
+        let point = AffinePoint::from_public_key(pubkey);
+        if point.is_some().into() {
+            Some(PublicKey(point.unwrap().into()))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the compressed SEC-1 encoding of this public key.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    /// Returns the uncompressed SEC-1 encoding of this public key.
+    pub(crate) fn decompress(&self) -> UncompressedPoint<NistP256> {
+        AffinePoint::from_public_key(&EcPublicKey::Compressed(self.0))
+            .unwrap()
+            .into()
+    }
+}

--- a/age-plugin-yubikey/src/plugin.rs
+++ b/age-plugin-yubikey/src/plugin.rs
@@ -1,0 +1,55 @@
+use age_core::format::{FileKey, Stanza};
+use age_plugin::{recipient::RecipientPluginV1, Error};
+use bech32::FromBase32;
+
+use crate::{format, p256::PublicKey, RECIPIENT_PREFIX};
+
+#[derive(Debug, Default)]
+pub(crate) struct RecipientPlugin {
+    recipients: Vec<PublicKey>,
+}
+
+impl RecipientPluginV1 for RecipientPlugin {
+    fn add_recipients<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        recipients: I,
+    ) -> Result<(), Vec<Error>> {
+        let errors: Vec<_> = recipients
+            .filter_map(|recipient| {
+                if let Some(pk) = bech32::decode(recipient)
+                    .ok()
+                    .and_then(|(hrp, data)| {
+                        if hrp == RECIPIENT_PREFIX {
+                            Some(data)
+                        } else {
+                            None
+                        }
+                    })
+                    .and_then(|data| Vec::from_base32(&data).ok())
+                    .and_then(|bytes| PublicKey::from_bytes(&bytes))
+                {
+                    self.recipients.push(pk);
+                    None
+                } else {
+                    Some(Error {
+                        kind: "recipient".to_owned(),
+                        message: "Invalid recipient".to_owned(),
+                    })
+                }
+            })
+            .collect();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn wrap_file_key(&mut self, file_key: &FileKey) -> Result<Vec<Stanza>, Vec<Error>> {
+        Ok(self
+            .recipients
+            .iter()
+            .map(|pk| format::RecipientLine::wrap_file_key(file_key, &pk).into())
+            .collect())
+    }
+}

--- a/age-plugin-yubikey/src/plugin.rs
+++ b/age-plugin-yubikey/src/plugin.rs
@@ -1,8 +1,14 @@
 use age_core::format::{FileKey, Stanza};
-use age_plugin::{recipient::RecipientPluginV1, Error};
+use age_plugin::{
+    identity::{Callbacks, IdentityPluginV1},
+    recipient::RecipientPluginV1,
+    Error,
+};
 use bech32::FromBase32;
+use std::collections::HashMap;
+use std::io;
 
-use crate::{format, p256::PublicKey, RECIPIENT_PREFIX};
+use crate::{format, p256::PublicKey, yubikey, IDENTITY_PREFIX, RECIPIENT_PREFIX};
 
 #[derive(Debug, Default)]
 pub(crate) struct RecipientPlugin {
@@ -51,5 +57,125 @@ impl RecipientPluginV1 for RecipientPlugin {
             .iter()
             .map(|pk| format::RecipientLine::wrap_file_key(file_key, &pk).into())
             .collect())
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct IdentityPlugin {
+    yubikeys: Vec<yubikey::Stub>,
+}
+
+impl IdentityPluginV1 for IdentityPlugin {
+    fn add_identities<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        identities: I,
+    ) -> Result<(), Vec<Error>> {
+        let errors: Vec<_> = identities
+            .filter_map(|identity| {
+                if let Some(stub) = bech32::decode(identity)
+                    .ok()
+                    .and_then(|(hrp, data)| {
+                        if hrp == IDENTITY_PREFIX.to_lowercase() {
+                            Some(data)
+                        } else {
+                            None
+                        }
+                    })
+                    .and_then(|data| Vec::from_base32(&data).ok())
+                    .and_then(|bytes| yubikey::Stub::from_bytes(&bytes))
+                {
+                    self.yubikeys.push(stub);
+                    None
+                } else {
+                    Some(Error {
+                        kind: "identity".to_owned(),
+                        message: "Invalid Yubikey stub".to_owned(),
+                    })
+                }
+            })
+            .collect();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn unwrap_file_keys(
+        &mut self,
+        files: HashMap<usize, Vec<Stanza>>,
+        mut callbacks: impl Callbacks,
+    ) -> io::Result<HashMap<usize, FileKey>> {
+        // Filter to files / stanzas for which we have matching YubiKeys
+        let mut candidate_stanzas: Vec<(
+            &yubikey::Stub,
+            HashMap<usize, Vec<format::RecipientLine>>,
+        )> = self
+            .yubikeys
+            .iter()
+            .map(|stub| (stub, HashMap::new()))
+            .collect();
+
+        for (file, stanzas) in &files {
+            for stanza in stanzas {
+                match format::RecipientLine::from_stanza(&stanza) {
+                    Some(Ok(line)) => {
+                        // A line will match at most one YubiKey.
+                        if let Some(files) =
+                            candidate_stanzas.iter_mut().find_map(|(stub, files)| {
+                                if stub.matches(&line) {
+                                    Some(files)
+                                } else {
+                                    None
+                                }
+                            })
+                        {
+                            files.entry(*file).or_default().push(line);
+                        }
+                    }
+                    Some(Err(e)) => callbacks.error(&e.kind, &e.message)?.unwrap(),
+                    None => (),
+                }
+            }
+        }
+
+        // Sort by effectiveness (YubiKey that can trial-decrypt the most stanzas)
+        candidate_stanzas.sort_by_key(|(_, files)| {
+            files
+                .iter()
+                .map(|(_, stanzas)| stanzas.len())
+                .sum::<usize>()
+        });
+        candidate_stanzas.reverse();
+
+        let mut file_keys = HashMap::with_capacity(files.len());
+        for (stub, files) in candidate_stanzas.iter() {
+            let mut conn = match stub.connect(&mut callbacks)? {
+                Ok(conn) => conn,
+                Err(e) => {
+                    callbacks.error(&e.kind, &e.message)?.unwrap();
+                    continue;
+                }
+            };
+
+            for (&file_index, stanzas) in files {
+                if file_keys.contains_key(&file_index) {
+                    // We decrypted this file with an earlier YubiKey.
+                    continue;
+                }
+
+                for line in stanzas {
+                    match conn.unwrap_file_key(&line) {
+                        Ok(file_key) => {
+                            // We've managed to decrypt this file!
+                            file_keys.entry(file_index).or_insert(file_key);
+                            break;
+                        }
+                        Err(e) => callbacks.error(&e.kind, &e.message)?.unwrap(),
+                    }
+                }
+            }
+        }
+        Ok(file_keys)
     }
 }

--- a/age-plugin-yubikey/src/yubikey.rs
+++ b/age-plugin-yubikey/src/yubikey.rs
@@ -5,6 +5,9 @@ use age_core::{
     primitives::{aead_decrypt, hkdf},
 };
 use age_plugin::{identity::Callbacks, Error};
+use bech32::ToBase32;
+use elliptic_curve::weierstrass::PublicKey as EcPublicKey;
+use p256::NistP256;
 use secrecy::ExposeSecret;
 use std::convert::TryInto;
 use std::hash;
@@ -19,6 +22,7 @@ use yubikey_piv::{
 use crate::{
     format::{piv_tag, RecipientLine, RECIPIENT_KEY_LABEL},
     p256::PublicKey,
+    IDENTITY_PREFIX,
 };
 
 /// A reference to an age key stored in a YubiKey.
@@ -38,6 +42,27 @@ impl hash::Hash for Stub {
 }
 
 impl Stub {
+    /// Returns a key stub and recipient for this `(Serial, SlotId, PublicKey)` tuple.
+    ///
+    /// Does not check that the `PublicKey` matches the given `(Serial, SlotId)` tuple;
+    /// this is checked at decryption time.
+    pub(crate) fn new(
+        serial: Serial,
+        slot: RetiredSlotId,
+        pubkey: &EcPublicKey<NistP256>,
+    ) -> Option<(Self, PublicKey)> {
+        PublicKey::from_pubkey(pubkey).map(|pk| {
+            (
+                Stub {
+                    serial,
+                    slot,
+                    tag: piv_tag(&pk),
+                },
+                pk,
+            )
+        })
+    }
+
     pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
         let serial = Serial::from(u32::from_le_bytes(bytes[0..4].try_into().unwrap()));
         let slot: RetiredSlotId = bytes[4].try_into().ok()?;
@@ -54,6 +79,13 @@ impl Stub {
         bytes.push(self.slot.into());
         bytes.extend_from_slice(&self.tag);
         bytes
+    }
+
+    /// Serializes this YubiKey stub as a string.
+    pub fn to_str(&self) -> String {
+        bech32::encode(IDENTITY_PREFIX, self.to_bytes().to_base32())
+            .expect("HRP is valid")
+            .to_uppercase()
     }
 
     pub(crate) fn matches(&self, line: &RecipientLine) -> bool {

--- a/age-plugin-yubikey/src/yubikey.rs
+++ b/age-plugin-yubikey/src/yubikey.rs
@@ -1,0 +1,184 @@
+//! Structs for handling YubiKeys.
+
+use age_core::{
+    format::FileKey,
+    primitives::{aead_decrypt, hkdf},
+};
+use age_plugin::{identity::Callbacks, Error};
+use secrecy::ExposeSecret;
+use std::convert::TryInto;
+use std::hash;
+use std::io;
+use yubikey_piv::{
+    certificate::{Certificate, PublicKeyInfo},
+    key::{decrypt_data, AlgorithmId, RetiredSlotId, SlotId},
+    yubikey::Serial,
+    YubiKey,
+};
+
+use crate::{
+    format::{piv_tag, RecipientLine, RECIPIENT_KEY_LABEL},
+    p256::PublicKey,
+};
+
+/// A reference to an age key stored in a YubiKey.
+#[derive(Debug, PartialEq)]
+pub struct Stub {
+    pub(crate) serial: Serial,
+    pub(crate) slot: RetiredSlotId,
+    pub(crate) tag: [u8; 4],
+}
+
+impl Eq for Stub {}
+
+impl hash::Hash for Stub {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.to_bytes());
+    }
+}
+
+impl Stub {
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let serial = Serial::from(u32::from_le_bytes(bytes[0..4].try_into().unwrap()));
+        let slot: RetiredSlotId = bytes[4].try_into().ok()?;
+        Some(Stub {
+            serial,
+            slot,
+            tag: bytes[5..9].try_into().unwrap(),
+        })
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(9);
+        bytes.extend_from_slice(&self.serial.0.to_le_bytes());
+        bytes.push(self.slot.into());
+        bytes.extend_from_slice(&self.tag);
+        bytes
+    }
+
+    pub(crate) fn matches(&self, line: &RecipientLine) -> bool {
+        self.tag == line.tag
+    }
+
+    pub(crate) fn connect(
+        &self,
+        callbacks: &mut dyn Callbacks,
+    ) -> io::Result<Result<Connection, Error>> {
+        let mut yubikey = match YubiKey::open_by_serial(self.serial) {
+            Ok(yk) => yk,
+            Err(_) => {
+                return Ok(Err(Error {
+                    kind: "identity".to_owned(),
+                    message: format!("Could not open YubiKey with serial {}", self.serial),
+                }))
+            }
+        };
+
+        // Read the pubkey from the YubiKey slot and check it still matches.
+        let pk = match Certificate::read(&mut yubikey, SlotId::Retired(self.slot))
+            .ok()
+            .and_then(|cert| match cert.subject_pki() {
+                PublicKeyInfo::EcP256(pubkey) => {
+                    PublicKey::from_pubkey(pubkey).filter(|pk| piv_tag(&pk) == self.tag)
+                }
+                _ => None,
+            }) {
+            Some(pk) => pk,
+            None => {
+                return Ok(Err(Error {
+                    kind: "identity".to_owned(),
+                    message: "A YubiKey stub did not match the YubiKey".to_owned(),
+                }))
+            }
+        };
+
+        let pin = match callbacks.request_secret(&format!(
+            "Enter PIN for YubiKey with serial {}",
+            self.serial
+        ))? {
+            Ok(pin) => pin,
+            Err(_) => {
+                return Ok(Err(Error {
+                    kind: "identity".to_owned(),
+                    message: format!("A PIN is required for YubiKey with serial {}", self.serial),
+                }))
+            }
+        };
+        if let Err(_) = yubikey.verify_pin(pin.expose_secret().as_bytes()) {
+            return Ok(Err(Error {
+                kind: "identity".to_owned(),
+                message: "Invalid YubiKey PIN".to_owned(),
+            }));
+        }
+
+        Ok(Ok(Connection {
+            yubikey,
+            pk,
+            slot: self.slot,
+            tag: self.tag,
+        }))
+    }
+}
+
+pub(crate) struct Connection {
+    yubikey: YubiKey,
+    pk: PublicKey,
+    slot: RetiredSlotId,
+    tag: [u8; 4],
+}
+
+impl Connection {
+    pub(crate) fn unwrap_file_key(&mut self, line: &RecipientLine) -> Result<FileKey, Error> {
+        assert_eq!(self.tag, line.tag);
+
+        let shared_secret = match decrypt_data(
+            &mut self.yubikey,
+            line.epk.decompress().as_bytes(),
+            AlgorithmId::EccP256,
+            SlotId::Retired(self.slot),
+        ) {
+            Ok(res) => res,
+            Err(_) => {
+                return Err(Error {
+                    kind: "stanza".to_owned(),
+                    message: "Failed to decrypt YubiKey stanza".to_owned(),
+                })
+            }
+        };
+
+        let mut salt = vec![];
+        salt.extend_from_slice(line.epk.as_bytes());
+        salt.extend_from_slice(self.pk.as_bytes());
+
+        let enc_key = hkdf(&salt, RECIPIENT_KEY_LABEL, shared_secret.as_ref());
+
+        // A failure to decrypt is fatal, because we assume that we won't
+        // encounter 32-bit collisions on the key tag embedded in the header.
+        match aead_decrypt(&enc_key, &line.encrypted_file_key) {
+            Ok(pt) => Ok(TryInto::<[u8; 16]>::try_into(&pt[..]).unwrap().into()),
+            Err(_) => Err(Error {
+                kind: "stanza".to_owned(),
+                message: "Failed to decrypt YubiKey stanza".to_owned(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use yubikey_piv::{key::RetiredSlotId, Serial};
+
+    use super::Stub;
+
+    #[test]
+    fn stub_round_trip() {
+        let stub = Stub {
+            serial: Serial::from(42),
+            slot: RetiredSlotId::R1,
+            tag: [7; 4],
+        };
+
+        let encoded = stub.to_bytes();
+        assert_eq!(Stub::from_bytes(&encoded), Some(stub));
+    }
+}

--- a/age-plugin/Cargo.toml
+++ b/age-plugin/Cargo.toml
@@ -9,5 +9,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+age-core = { version = "0.4.0", path = "../age-core", features = ["plugin"] }
 bech32 = "0.7.2"
 chrono = "0.4"

--- a/age-plugin/Cargo.toml
+++ b/age-plugin/Cargo.toml
@@ -9,3 +9,5 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+bech32 = "0.7.2"
+chrono = "0.4"

--- a/age-plugin/Cargo.toml
+++ b/age-plugin/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 age-core = { version = "0.4.0", path = "../age-core", features = ["plugin"] }
 bech32 = "0.7.2"
 chrono = "0.4"
+secrecy = "0.7"

--- a/age-plugin/Cargo.toml
+++ b/age-plugin/Cargo.toml
@@ -13,3 +13,6 @@ age-core = { version = "0.4.0", path = "../age-core", features = ["plugin"] }
 bech32 = "0.7.2"
 chrono = "0.4"
 secrecy = "0.7"
+
+[dev-dependencies]
+gumdrop = "0.8"

--- a/age-plugin/Cargo.toml
+++ b/age-plugin/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "age-plugin"
+description = "[BETA] API for writing age plugins."
+version = "0.0.0"
+authors = ["Jack Grigg <thestr4d@gmail.com>"]
+repository = "https://github.com/str4d/rage"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]

--- a/age-plugin/README.md
+++ b/age-plugin/README.md
@@ -1,0 +1,20 @@
+# age-plugin Rust library
+
+This crate provides an API for building age plugins.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/age-plugin/examples/age-plugin-unencrypted.rs
+++ b/age-plugin/examples/age-plugin-unencrypted.rs
@@ -1,0 +1,128 @@
+use age_core::format::{FileKey, Stanza};
+use age_plugin::{
+    identity::{self, Callbacks, IdentityPluginV1},
+    print_new_identity,
+    recipient::{self, RecipientPluginV1},
+    Error,
+};
+use gumdrop::Options;
+use secrecy::ExposeSecret;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::io;
+
+const PLUGIN_NAME: &str = "unencrypted";
+const RECIPIENT_TAG: &str = PLUGIN_NAME;
+
+struct RecipientPlugin;
+
+impl RecipientPluginV1 for RecipientPlugin {
+    fn add_recipients<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        recipients: I,
+    ) -> Result<(), Vec<Error>> {
+        let errors = recipients
+            .filter_map(|recipient| {
+                if recipient.contains(PLUGIN_NAME) {
+                    // A real plugin would store the recipient here.
+                    None
+                } else {
+                    Some(Error {
+                        kind: "recipient".to_owned(),
+                        message: "invalid recipient".to_owned(),
+                    })
+                }
+            })
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn wrap_file_key(&mut self, file_key: &FileKey) -> Result<Vec<Stanza>, Vec<Error>> {
+        // A real plugin would wrap the file key here.
+        Ok(vec![Stanza {
+            tag: RECIPIENT_TAG.to_owned(),
+            args: vec!["does".to_owned(), "nothing".to_owned()],
+            body: file_key.expose_secret().to_vec(),
+        }])
+    }
+}
+
+struct IdentityPlugin;
+
+impl IdentityPluginV1 for IdentityPlugin {
+    fn add_identities<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        identities: I,
+    ) -> Result<(), Vec<Error>> {
+        let mut errors = vec![];
+        for identity in identities {
+            if identity.contains(&PLUGIN_NAME.to_uppercase()) {
+                // A real plugin would store the identity.
+            } else {
+                errors.push(Error {
+                    kind: "identity".to_owned(),
+                    message: "invalid identity".to_owned(),
+                });
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn unwrap_file_keys(
+        &mut self,
+        files: HashMap<usize, Vec<Stanza>>,
+        mut callbacks: impl Callbacks,
+    ) -> io::Result<HashMap<usize, FileKey>> {
+        let mut file_keys = HashMap::with_capacity(files.len());
+        for (file_index, stanzas) in files {
+            for stanza in stanzas {
+                if stanza.tag == RECIPIENT_TAG {
+                    // A real plugin would attempt to unwrap the file key with the stored
+                    // identities.
+                    let _ = callbacks.prompt("This identity does nothing!")?;
+                    file_keys.entry(file_index).or_insert(FileKey::from(
+                        TryInto::<[u8; 16]>::try_into(&stanza.body[..]).unwrap(),
+                    ));
+                    break;
+                } else {
+                    callbacks.error("stanza", "unsupported stanza")?.unwrap();
+                }
+            }
+        }
+        Ok(file_keys)
+    }
+}
+
+#[derive(Debug, Options)]
+struct PluginOptions {
+    #[options(help = "print help message")]
+    help: bool,
+
+    #[options(help = "run as an age recipient plugin", no_short)]
+    recipient_plugin_v1: bool,
+
+    #[options(help = "run as an age identity plugin", no_short)]
+    identity_plugin_v1: bool,
+}
+
+fn main() -> io::Result<()> {
+    let opts = PluginOptions::parse_args_default_or_exit();
+
+    if opts.recipient_plugin_v1 {
+        recipient::run_v1(RecipientPlugin)
+    } else if opts.identity_plugin_v1 {
+        identity::run_v1(IdentityPlugin)
+    } else {
+        // A real plugin would generate a new identity here.
+        print_new_identity(PLUGIN_NAME, &[], &[]);
+        Ok(())
+    }
+}

--- a/age-plugin/src/identity.rs
+++ b/age-plugin/src/identity.rs
@@ -1,0 +1,169 @@
+//! Identity plugin helpers.
+
+use age_core::{
+    format::{FileKey, Stanza},
+    plugin::{self, BidirSend, Connection},
+};
+use secrecy::{ExposeSecret, SecretString};
+use std::collections::HashMap;
+use std::io;
+
+use super::Error;
+
+/// The interface that age plugins can use to interact with an age implementation.
+pub trait Callbacks {
+    /// Shows a message to the user.
+    ///
+    /// This can be used to prompt the user to take some physical action, such as
+    /// inserting a hardware key.
+    fn prompt(&mut self, message: &str) -> plugin::Result<(), ()>;
+
+    /// Requests a secret value from the user, such as a passphrase.
+    ///
+    /// `message` will be displayed to the user, providing context for the request.
+    fn request_secret(&mut self, message: &str) -> plugin::Result<SecretString, ()>;
+
+    /// Sends an error.
+    fn error(&mut self, kind: &str, message: &str) -> plugin::Result<(), ()>;
+}
+
+/// The interface that age implementations will use to interact with an age plugin.
+pub trait IdentityPluginV1 {
+    /// Stores an identity that the user would like to use for decrypting age files.
+    ///
+    /// `plugin_name` identifies the plugin that generated this identity. In most cases,
+    /// it will be identical to the name of the plugin implementing this trait. However,
+    /// age implementations look up plugins by their binary name, and if a plugin is
+    /// renamed or aliased in the user's OS environment, it is possible for a plugin to
+    /// receive identities that it does not support. Implementations must check
+    /// `plugin_name` before using `identity`.
+    fn add_identities<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        identities: I,
+    ) -> Result<(), Vec<Error>>;
+
+    /// Attempts to unwrap the file key contained within the given age recipient stanza,
+    /// using identities previously stored via [`add_identity`].
+    ///
+    /// `prompt` shows a message to the user. This can be used to prompt the user to take
+    /// some physical action, such as inserting a hardware key.
+    ///
+    /// `request_secret` requests a secret value from the user, such as a passphrase. It
+    /// takes a `message` will be displayed to the user, providing context for the
+    /// request.
+    ///
+    /// [`add_identity`]: AgePlugin::add_identity
+    fn unwrap_file_keys(
+        &mut self,
+        files: HashMap<usize, Vec<Stanza>>,
+        callbacks: impl Callbacks,
+    ) -> io::Result<HashMap<usize, FileKey>>;
+}
+
+/// The interface that age plugins can use to interact with an age implementation.
+struct BidirCallbacks<'a, 'b, R: io::Read, W: io::Write>(&'b mut BidirSend<'a, R, W>);
+
+impl<'a, 'b, R: io::Read, W: io::Write> Callbacks for BidirCallbacks<'a, 'b, R, W> {
+    /// Shows a message to the user.
+    ///
+    /// This can be used to prompt the user to take some physical action, such as
+    /// inserting a hardware key.
+    fn prompt(&mut self, message: &str) -> plugin::Result<(), ()> {
+        self.0
+            .send("prompt", &[], message.as_bytes())
+            .map(|res| res.map(|_| ()))
+    }
+
+    /// Requests a secret value from the user, such as a passphrase.
+    ///
+    /// `message` will be displayed to the user, providing context for the request.
+    fn request_secret(&mut self, message: &str) -> plugin::Result<SecretString, ()> {
+        self.0
+            .send("request-secret", &[], message.as_bytes())
+            .and_then(|res| match res {
+                Ok(s) => String::from_utf8(s.body)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "secret is not UTF-8"))
+                    .map(|s| Ok(SecretString::new(s))),
+                Err(()) => Ok(Err(())),
+            })
+    }
+
+    fn error(&mut self, kind: &str, message: &str) -> plugin::Result<(), ()> {
+        self.0
+            .send("error", &[kind], message.as_bytes())
+            .map(|res| res.map(|_| ()))
+    }
+}
+
+/// Runs the recipient plugin v1 protocol.
+///
+/// This should be triggered if the `--identity-plugin-v1` flag is provided as an argument
+/// when starting the plugin.
+pub fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
+    let mut conn = Connection::accept();
+
+    // Phase 1: receive identities and stanzas
+    let (identities, recipient_stanzas) = {
+        let (identities, rest) = conn
+            .unidir_receive()?
+            .into_iter()
+            .partition::<Vec<_>, _>(|s| s.tag == "add-identity");
+        (
+            identities,
+            rest.into_iter()
+                .filter(|s| s.tag == "recipient-stanza")
+                .map(|mut s| {
+                    let file_index = s.args.remove(0);
+                    s.tag = s.args.remove(0);
+                    file_index.parse::<usize>().ok().map(|i| (i, s))
+                })
+                .collect::<Vec<_>>(),
+        )
+    };
+
+    // Phase 2: interactively unwrap
+    conn.bidir_send(|mut phase| {
+        if let Err(errors) =
+            plugin.add_identities(identities.iter().map(|s| s.args.first().unwrap().as_str()))
+        {
+            for e in errors {
+                phase
+                    .send("error", &[&e.kind], e.message.as_bytes())?
+                    .unwrap();
+            }
+        } else {
+            let mut stanzas = HashMap::new();
+            for recipient_stanza in recipient_stanzas {
+                if let Some((file_index, stanza)) = recipient_stanza {
+                    stanzas
+                        .entry(file_index)
+                        .or_insert_with(Vec::new)
+                        .push(stanza);
+                } else {
+                    phase
+                        .send(
+                            "error",
+                            &["stanza"],
+                            "Invalid recipient-stanza command".as_bytes(),
+                        )?
+                        .unwrap();
+                }
+            }
+
+            for (file_index, file_key) in
+                plugin.unwrap_file_keys(stanzas, BidirCallbacks(&mut phase))?
+            {
+                phase
+                    .send(
+                        "file-key",
+                        &[&format!("{}", file_index)],
+                        file_key.expose_secret(),
+                    )?
+                    .unwrap();
+            }
+        }
+        Ok(())
+    })?;
+
+    Ok(())
+}

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![deny(missing_docs)]
 
+pub mod identity;
 pub mod recipient;
 
 // Plugin HRPs are age1[name] and AGE-PLUGIN-[NAME]-

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -1,7 +1,39 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+//! This is a helper crate for implementing age plugins.
+
+#![forbid(unsafe_code)]
+// Catch documentation errors caused by code changes.
+#![deny(intra_doc_link_resolution_failure)]
+#![deny(missing_docs)]
+
+// Plugin HRPs are age1[name] and AGE-PLUGIN-[NAME]-
+const PLUGIN_RECIPIENT_PREFIX: &str = "age1";
+const PLUGIN_IDENTITY_PREFIX: &str = "age-plugin-";
+
+/// Prints the newly-created identity and corresponding recipient to standard out.
+///
+/// A "created" time is included in the output, set to the current local time.
+pub fn print_new_identity(plugin_name: &str, identity: &[u8], recipient: &[u8]) {
+    use bech32::ToBase32;
+
+    println!(
+        "# created: {}",
+        chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    );
+    println!(
+        "# recipient: {}",
+        bech32::encode(
+            &format!("{}{}", PLUGIN_RECIPIENT_PREFIX, plugin_name),
+            recipient.to_base32(),
+        )
+        .expect("HRP is valid")
+    );
+    println!(
+        "{}",
+        bech32::encode(
+            &format!("{}{}-", PLUGIN_IDENTITY_PREFIX, plugin_name),
+            identity.to_base32(),
+        )
+        .expect("HRP is valid")
+        .to_uppercase()
+    );
 }

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -5,9 +5,19 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![deny(missing_docs)]
 
+pub mod recipient;
+
 // Plugin HRPs are age1[name] and AGE-PLUGIN-[NAME]-
 const PLUGIN_RECIPIENT_PREFIX: &str = "age1";
 const PLUGIN_IDENTITY_PREFIX: &str = "age-plugin-";
+
+/// An error message within the plugin protocol.
+pub struct Error {
+    /// The error kind. Should be a single word.
+    pub kind: String,
+    /// The error message, to be displayed to the user.
+    pub message: String,
+}
 
 /// Prints the newly-created identity and corresponding recipient to standard out.
 ///

--- a/age-plugin/src/recipient.rs
+++ b/age-plugin/src/recipient.rs
@@ -1,0 +1,108 @@
+//! Recipient plugin helpers.
+
+use age_core::{
+    format::{FileKey, Stanza},
+    plugin::Connection,
+};
+use std::convert::TryInto;
+use std::io;
+
+use super::Error;
+
+/// The interface that age implementations will use to interact with an age plugin.
+pub trait RecipientPluginV1 {
+    /// Stores recipients that the user would like to encrypt age files.
+    ///
+    /// `plugin_name` identifies the plugin that generated this identity. In most cases,
+    /// it will be identical to the name of the plugin implementing this trait. However,
+    /// age implementations look up plugins by their binary name, and if a plugin is
+    /// renamed or aliased in the user's OS environment, it is possible for a plugin to
+    /// receive identities that it does not support. Implementations must check
+    /// `plugin_name` before using `identity`.
+    fn add_recipients<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        recipients: I,
+    ) -> Result<(), Vec<Error>>;
+
+    /// Wraps `file_key` in an age recipient stanza that can be unwrapped by `recipient`.
+    ///
+    /// `plugin_name` identifies the plugin that generated this recipient. In most cases,
+    /// it will be identical to the name of the plugin implementing this trait. However,
+    /// age implementations look up plugins by their binary name, and if a plugin is
+    /// renamed or aliased in the user's OS environment, it is possible for a plugin to
+    /// receive identities that it does not support. Implementations must check
+    /// `plugin_name` before using `recipient`.
+    fn wrap_file_key(&mut self, file_key: &FileKey) -> Result<Vec<Stanza>, Vec<Error>>;
+}
+
+/// Runs the recipient plugin v1 protocol.
+///
+/// This should be triggered if the `--recipient-plugin-v1` flag is provided as an
+/// argument when starting the plugin.
+pub fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
+    let mut conn = Connection::accept();
+
+    // Phase 1: collect recipients
+    let recipients = conn
+        .unidir_receive()?
+        .into_iter()
+        .filter(|s| s.tag == "add-recipient" && s.args.len() == 1)
+        .collect::<Vec<_>>();
+    if recipients.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Need at least one add-recipient",
+        ));
+    }
+
+    // Phase 2: return errors
+    conn.unidir_send(|mut phase| {
+        if let Err(errors) =
+            plugin.add_recipients(recipients.iter().map(|s| s.args.first().unwrap().as_str()))
+        {
+            for error in errors {
+                phase.send("error", &[&error.kind], error.message.as_bytes())?;
+            }
+        }
+        Ok(())
+    })?;
+
+    // Phase 3: receive file key to be wrapped
+    // TODO: How should errors about invalid state machine messages be returned?
+    let file_key = {
+        let mut res = conn
+            .unidir_receive()?
+            .into_iter()
+            .filter(|s| s.tag == "wrap-file-key");
+        match (res.next(), res.next()) {
+            (Some(s), None) => TryInto::<[u8; 16]>::try_into(&s.body[..])
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid file key length"))
+                .map(FileKey::from),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "should receive a single wrap-file-key command",
+                ))
+            }
+        }
+    }?;
+
+    // Phase 4: wrap the file key
+    conn.unidir_send(|mut phase| {
+        match plugin.wrap_file_key(&file_key) {
+            Ok(stanzas) => {
+                for stanza in stanzas {
+                    phase.send_stanza("recipient-stanza", &["0"], &stanza)?;
+                }
+            }
+            Err(errors) => {
+                for e in errors {
+                    phase.send("error", &[&e.kind], e.message.as_bytes())?;
+                }
+            }
+        }
+        Ok(())
+    })?;
+
+    Ok(())
+}

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -76,6 +76,10 @@ dirs = { version = "3.0.1", optional = true }
 pinentry = { version = "0.2", optional = true }
 rpassword = { version = "5", optional = true }
 
+[target.'cfg(any(unix, windows))'.dependencies]
+# Plugin management
+which = { version = "4", optional = true }
+
 [dev-dependencies]
 criterion = "0.3"
 criterion-cycles-per-byte = "0.1"
@@ -88,6 +92,7 @@ default = []
 armor = []
 async = ["futures"]
 cli-common = ["console", "dirs", "pinentry", "rpassword"]
+plugin = ["age-core/plugin", "which"]
 ssh = [
     "aes",
     "aes-ctr",

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -40,7 +40,7 @@ scrypt = { version = "0.4", default-features = false }
 rand = "0.7"
 
 # - Key encoding
-bech32 = "0.7"
+bech32 = "0.7.2"
 
 # OpenSSH-specific dependencies:
 # - RSAES-OAEP from RFC 8017 with SHA-256 and MGF1

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -161,6 +161,10 @@ pub use primitives::armor;
 #[cfg_attr(docsrs, doc(cfg(feature = "cli-common")))]
 pub mod cli_common;
 
+#[cfg(feature = "plugin")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plugin")))]
+pub mod plugin;
+
 #[cfg(feature = "ssh")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ssh")))]
 pub mod ssh;

--- a/age/src/plugin.rs
+++ b/age/src/plugin.rs
@@ -1,0 +1,143 @@
+//! Support for the age plugin system.
+
+use age_core::{
+    format::{FileKey, Stanza},
+    plugin::Connection,
+};
+use secrecy::ExposeSecret;
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+use std::process::{ChildStdin, ChildStdout};
+
+use crate::{error::EncryptError, util::parse_bech32};
+
+// Plugin HRPs are age1[name] and AGE-PLUGIN-[NAME]-
+const PLUGIN_RECIPIENT_PREFIX: &str = "age1";
+
+/// A plugin-compatible recipient.
+#[derive(Clone)]
+pub struct Recipient {
+    /// The plugin name, extracted from `recipient`.
+    name: String,
+    /// The recipient.
+    recipient: String,
+}
+
+impl std::str::FromStr for Recipient {
+    type Err = &'static str;
+
+    /// Parses a plugin recipient from a string.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_bech32(s)
+            .ok_or("invalid Bech32 encoding")
+            .and_then(|(hrp, _)| {
+                if hrp.len() > PLUGIN_RECIPIENT_PREFIX.len()
+                    && hrp.starts_with(PLUGIN_RECIPIENT_PREFIX)
+                {
+                    Ok(Recipient {
+                        name: hrp.split_at(PLUGIN_RECIPIENT_PREFIX.len()).1.to_owned(),
+                        recipient: s.to_owned(),
+                    })
+                } else {
+                    Err("invalid HRP")
+                }
+            })
+    }
+}
+
+impl fmt::Display for Recipient {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.recipient)
+    }
+}
+
+impl Recipient {
+    /// Returns the plugin name for this recipient.
+    pub fn plugin(&self) -> &str {
+        &self.name
+    }
+}
+
+/// An age plugin.
+struct Plugin(PathBuf);
+
+impl Plugin {
+    /// Finds the age plugin with the given name.
+    fn new(name: &str) -> which::Result<Self> {
+        let binary_name = format!("age-plugin-{}", name);
+        which::which(binary_name).map(Plugin)
+    }
+
+    fn connect(&self, state_machine: &str) -> io::Result<Connection<ChildStdout, ChildStdin>> {
+        Connection::open(&self.0, state_machine)
+    }
+}
+
+/// TODO
+pub struct RecipientPluginV1 {
+    plugin: Plugin,
+    recipients: Vec<Recipient>,
+}
+
+impl RecipientPluginV1 {
+    /// TODO
+    pub fn new(plugin_name: &str, recipients: &[Recipient]) -> which::Result<Self> {
+        Plugin::new(plugin_name).map(|plugin| RecipientPluginV1 {
+            plugin,
+            recipients: recipients
+                .iter()
+                .filter(|r| r.name == plugin_name)
+                .cloned()
+                .collect(),
+        })
+    }
+}
+
+impl crate::Recipient for RecipientPluginV1 {
+    fn wrap_file_key(&self, file_key: &FileKey) -> Result<Vec<Stanza>, EncryptError> {
+        // Open connection
+        let mut conn = self.plugin.connect("--recipient-plugin-v1")?;
+
+        // Phase 1: add-recipient
+        conn.unidir_send(|mut phase| {
+            for recipient in &self.recipients {
+                phase.send("add-recipient", &[&recipient.recipient], &[])?;
+            }
+            Ok(())
+        })?;
+
+        // Phase 2: check for errors
+        let errors = conn.unidir_receive()?;
+        assert!(errors.is_empty());
+
+        // Phase 3: request wrapping
+        conn.unidir_send(|mut phase| phase.send("wrap-file-key", &[], file_key.expose_secret()))?;
+
+        // Phase 4: collect either stanzas or errors
+        let (stanzas, errors) = {
+            let (stanzas, rest) = conn
+                .unidir_receive()?
+                .into_iter()
+                .partition::<Vec<_>, _>(|s| s.tag == "recipient-stanza");
+            (
+                stanzas,
+                rest.into_iter()
+                    .filter(|s| s.tag == "error")
+                    .collect::<Vec<_>>(),
+            )
+        };
+        match (stanzas.is_empty(), errors.is_empty()) {
+            (false, true) => Ok(stanzas
+                .into_iter()
+                .map(|mut s| {
+                    s.args.remove(0);
+                    s.tag = s.args.remove(0);
+                    s
+                })
+                .collect()),
+            (true, false) => unimplemented!(),
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -152,6 +152,12 @@ impl<R: AsyncRead + Unpin> PassphraseDecryptor<R> {
 
 /// Callbacks that might be triggered during decryption.
 pub trait Callbacks {
+    /// Shows a message to the user.
+    ///
+    /// This can be used to prompt the user to take some physical action, such as
+    /// inserting a hardware key.
+    fn prompt(&self, message: &str);
+
     /// Requests a passphrase to decrypt a key.
     fn request_passphrase(&self, description: &str) -> Option<SecretString>;
 }

--- a/rage/Cargo.toml
+++ b/rage/Cargo.toml
@@ -43,7 +43,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 # rage and rage-keygen dependencies
-age = { version = "0.4.0", path = "../age", features = ["armor", "cli-common"] }
+age = { version = "0.4.0", path = "../age", features = ["armor", "cli-common", "plugin"] }
 chrono = "0.4"
 console = "0.12"
 env_logger = "0.7"

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -23,6 +23,7 @@ enum Error {
     MissingFilename,
     MissingIdentities(String),
     MissingMountpoint,
+    MissingPlugin(String),
     MissingType,
     UnknownType(String),
     UnsupportedKey(String, age::ssh::UnsupportedKey),
@@ -62,6 +63,10 @@ impl fmt::Debug for Error {
                 write!(f, "    {}", default_filename)
             }
             Error::MissingMountpoint => writeln!(f, "Missing mountpoint"),
+            Error::MissingPlugin(name) => {
+                writeln!(f, "Could not find '{}' on the PATH.", name)?;
+                write!(f, "Have you installed the plugin?")
+            }
             Error::MissingType => writeln!(f, "Missing -t/--types"),
             Error::UnknownType(t) => writeln!(f, "Unknown filesystem type \"{}\"", t),
             Error::UnsupportedKey(filename, k) => k.display(f, Some(filename.as_str())),
@@ -195,6 +200,7 @@ fn main() -> Result<(), Error> {
                 opts.identity,
                 |default_filename| Error::MissingIdentities(default_filename.to_string()),
                 |filename| Error::IdentityNotFound(filename),
+                Error::MissingPlugin,
                 Error::UnsupportedKey,
             )?;
 

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -83,6 +83,7 @@ pub(crate) enum DecryptError {
     IdentityNotFound(String),
     Io(io::Error),
     MissingIdentities(String),
+    MissingPlugin(String),
     PassphraseFlag,
     #[cfg(not(unix))]
     PassphraseWithoutFileArgument,
@@ -127,6 +128,10 @@ impl fmt::Display for DecryptError {
                 writeln!(f, "Did you forget to specify -i/--identity?")?;
                 writeln!(f, "You can also store default identities in this file:")?;
                 write!(f, "    {}", default_filename)
+            }
+            DecryptError::MissingPlugin(name) => {
+                writeln!(f, "Could not find '{}' on the PATH.", name)?;
+                write!(f, "Have you installed the plugin?")
             }
             DecryptError::PassphraseFlag => {
                 writeln!(f, "-p/--passphrase can't be used with -d/--decrypt.")?;

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -7,6 +7,7 @@ pub(crate) enum EncryptError {
     InvalidRecipient(String),
     Io(io::Error),
     Minreq(minreq::Error),
+    MissingPlugin(String),
     MissingRecipients,
     MixedRecipientAndPassphrase,
     PassphraseWithoutFileArgument,
@@ -55,6 +56,10 @@ impl fmt::Display for EncryptError {
             EncryptError::InvalidRecipient(r) => write!(f, "Invalid recipient '{}'", r),
             EncryptError::Io(e) => write!(f, "{}", e),
             EncryptError::Minreq(e) => write!(f, "{}", e),
+            EncryptError::MissingPlugin(name) => {
+                writeln!(f, "Could not find '{}' on the PATH.", name)?;
+                write!(f, "Have you installed the plugin?")
+            }
             EncryptError::MissingRecipients => {
                 writeln!(f, "Missing recipients.")?;
                 write!(f, "Did you forget to specify -r/--recipient?")

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -399,6 +399,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
                     error::DecryptError::MissingIdentities(default_filename.to_string())
                 },
                 error::DecryptError::IdentityNotFound,
+                error::DecryptError::MissingPlugin,
                 #[cfg(feature = "ssh")]
                 error::DecryptError::UnsupportedKey,
             )?;


### PR DESCRIPTION
### Discuss this draft on the [age-dev mailing list thread](https://groups.google.com/forum/#!topic/age-dev/lKyzz61iphM)!

### Current draft specification:

age PIV identities use ECC P-256 keys, generated on the hardware token, with certificates that never expire.

For hardware tokens that support PIN and/or touch policies (such as YubiKeys), the default PIN policy is "once per session", and the default touch policy is "every decryption".

A PIV recipient has the following form:
```
Bech32("age1piv", SEC-1-C(public key))
```
where `SEC-1-C` is the 33-byte compressed SEC-1 encoding.

A PIV recipient line is of the form:
```
-> piv encode(SHA-256(recipient)[:4]) encode(SEC-1-C(ECDH(ephemeral secret, p256-basepoint)))\n
encode(encrypt[HKDF[salt, label](ECDH(ephemeral secret, public key))](file key))\n
```
where `ephemeral secret` is a random scalar within the scalar field of P-256 and MUST be new for every file key, `salt` is `SEC-1-C(ECDH(ephemeral secret, basepoint)) || SEC-1-C(public key)`, and `label` is `age-encryption.org/v1/piv`.

A YubiKey "identity" is managed locally as a key stub with the following form:
```
Uppercase(Bech32("age-yubikey-stub-", serial || slot || SHA-256(recipient)[:4]))
```
The stub may exist in files alongside age X25519 secret keys, and is similarly passed to the age / rage binary with the -i flag.

Note that the common tag in the recipient line and key stub means that recipients can trivially identify whether they can decrypt a particular recipient line, at the cost of making recipients linkable across different encrypted files.

---

Usage example (responses out-of-date):
```
$ cargo install --path . --features yubikey
$ rage-keygen --yubikey -o keystub.txt
Enter PIN for YubiKey with serial 12345678: [hidden]
Use the up/down arrow keys to select a PIV slot (q to quit): Retired(R1) (Empty)
Select a PIN policy: Once   (A PIN is required once per session, if set)
Select a touch policy: Always (A physical touch is required for every decryption),
Generate new key in Retired(R1) slot? yes
$ cat keystub.txt 
# created: 2019-12-07T23:13:09Z
# yubikey:A_y2TWFFIZ8AhuFCjpxGzt_qiZrwMfEyDG6M8fqgG3ET
AGE_YUBIKEY_STUB_00bc614e_9d_6ecc74ff
$ echo "YubiKey FTW!" | rage -o test.age -r yubikey:A_y2TWFFIZ8AhuFCjpxGzt_qiZrwMfEyDG6M8fqgG3ET
$ rage -d -i keystub.txt test.age
Enter PIN for YubiKey with serial 12345678: [hidden]
YubiKey FTW!
```