### PR TITLE
Reorganise dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,6 @@ dependencies = [
 name = "age"
 version = "0.1.0"
 dependencies = [
- "aead 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,7 +63,6 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuse_mt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,6 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuse_mt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ sha2 = "0.8"
 scrypt = { version = "0.2", default-features = false }
 
 # - CSPRNG
-getrandom = "0.1"
 rand = "0.7"
 
 # - Key encoding

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,33 +15,69 @@ default-run = "rage"
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.1"
-aes-ctr = "0.3"
+#
+# Library dependencies
+#
+
+# Dependencies required by the age specification:
+# - Base64 from RFC 4648
 base64 = "0.10"
-bech32 = "0.7"
-blowfish = { version = "0.4", features = ["bcrypt"] }
-byteorder = "1"
+
+# - ChaCha20-Poly1305 from RFC 7539
+aead = "0.1"
 chacha20poly1305 = "0.1"
-cookie-factory = "0.3"
-crypto-mac = "0.7"
-curve25519-dalek = "2"
 generic-array = "0.12"
-getrandom = "0.1"
+
+# - X25519 from RFC 7748
+x25519-dalek = "0.6"
+
+# - HKDF from RFC 5869 with SHA-256
+# - HMAC from RFC 2104 with SHA-256
 hkdf = "0.8"
 hmac = "0.7"
-nom = "5"
-num-traits = "0.2"
-pbkdf2 = "0.3"
-radix64 = "0.6"
-rand = "0.7"
-scrypt = { version = "0.2", default-features = false }
-secrecy = "0.5"
 sha2 = "0.8"
-x25519-dalek = "0.6"
+
+# - scrypt from RFC 7914
+scrypt = { version = "0.2", default-features = false }
+
+# - CSPRNG
+getrandom = "0.1"
+rand = "0.7"
+
+# - Key encoding
+bech32 = "0.7"
+
+# OpenSSH-specific dependencies:
+# - RSAES-OAEP from RFC 8017 with SHA-256 and MGF1 (behind unstable feature flag)
+num-traits = "0.2"
+rsa = { version = "0.2", git = "https://github.com/str4d/RSA", branch = "oaep", optional = true }
+
+# - Conversion of public keys from from Ed25519 to X25519
+curve25519-dalek = "2"
+
+# - bcrypt (required for encrypted keys)
+blowfish = { version = "0.4", features = ["bcrypt"] }
+byteorder = "1"
+crypto-mac = "0.7"
+pbkdf2 = "0.3"
+
+# - Encrypted keys
+aes-ctr = "0.3"
+
+# Parsing
+cookie-factory = "0.3"
+nom = "5"
+
+# Armor writing
+radix64 = "0.6"
+
+# Secret management
+secrecy = "0.5"
 zeroize = "1"
 
-# Unstable dependencies
-rsa = { version = "0.2", git = "https://github.com/str4d/RSA", branch = "oaep", optional = true }
+#
+# Tool dependencies
+#
 
 # Common CLI dependencies
 dialoguer = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bech32 = "0.7"
 
 # OpenSSH-specific dependencies:
 # - RSAES-OAEP from RFC 8017 with SHA-256 and MGF1 (behind unstable feature flag)
-num-traits = "0.2"
+num-traits = { version = "0.2", optional = true }
 rsa = { version = "0.2", git = "https://github.com/str4d/RSA", branch = "oaep", optional = true }
 
 # - Conversion of public keys from from Ed25519 to X25519
@@ -108,7 +108,7 @@ default = ["cli"]
 cli-common = ["dialoguer", "dirs", "gumdrop", "log"]
 cli = ["cli-common", "chrono", "console", "env_logger", "minreq"]
 mount = ["cli-common", "env_logger", "fuse_mt", "libc", "tar", "time", "zip"]
-unstable = ["rsa"]
+unstable = ["num-traits", "rsa"]
 
 [[bin]]
 name = "rage-mount"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ maintenance = { status = "experimental" }
 base64 = "0.10"
 
 # - ChaCha20-Poly1305 from RFC 7539
-aead = "0.1"
 chacha20poly1305 = "0.1"
-generic-array = "0.12"
 
 # - X25519 from RFC 7748
 x25519-dalek = "0.6"

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,8 +44,8 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<aead::Error> for Error {
-    fn from(_: aead::Error) -> Self {
+impl From<chacha20poly1305::aead::Error> for Error {
+    fn from(_: chacha20poly1305::aead::Error) -> Self {
         Error::DecryptionFailed
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,8 +56,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<crypto_mac::MacError> for Error {
-    fn from(_: crypto_mac::MacError) -> Self {
+impl From<hmac::crypto_mac::MacError> for Error {
+    fn from(_: hmac::crypto_mac::MacError) -> Self {
         Error::InvalidMac
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -68,7 +68,7 @@ impl Header {
         header
     }
 
-    pub(crate) fn verify_mac(&self, mac_key: [u8; 32]) -> Result<(), crypto_mac::MacError> {
+    pub(crate) fn verify_mac(&self, mac_key: [u8; 32]) -> Result<(), hmac::crypto_mac::MacError> {
         let mut mac = HmacWriter::new(mac_key);
         cookie_factory::gen(write::canonical_header_minus_mac(self), &mut mac)
             .expect("can serialize Header into HmacWriter");

--- a/src/format/scrypt.rs
+++ b/src/format/scrypt.rs
@@ -1,4 +1,4 @@
-use getrandom::getrandom;
+use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::time::{Duration, SystemTime};
 
@@ -48,7 +48,7 @@ pub(crate) struct RecipientLine {
 impl RecipientLine {
     pub(crate) fn wrap_file_key(file_key: &FileKey, passphrase: &SecretString) -> Self {
         let mut salt = [0; 16];
-        getrandom(&mut salt).expect("Should not fail");
+        OsRng.fill_bytes(&mut salt);
 
         let mut inner_salt = vec![];
         inner_salt.extend_from_slice(SCRYPT_SALT_LABEL);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -2,8 +2,7 @@
 
 use bech32::{FromBase32, ToBase32};
 use curve25519_dalek::edwards::EdwardsPoint;
-use getrandom::getrandom;
-use rand::rngs::OsRng;
+use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::convert::TryInto;
 use std::fmt;
@@ -43,7 +42,7 @@ pub(crate) struct FileKey(pub(crate) Secret<[u8; 16]>);
 impl FileKey {
     pub(crate) fn generate() -> Self {
         let mut file_key = [0; 16];
-        getrandom(&mut file_key).expect("Should not fail");
+        OsRng.fill_bytes(&mut file_key);
         FileKey(Secret::new(file_key))
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,11 +1,12 @@
 //! Primitive cryptographic operations used by `age`.
 
-use aead::{Aead, NewAead};
-use chacha20poly1305::ChaCha20Poly1305;
-use generic_array::typenum::U32;
+use chacha20poly1305::{
+    aead::{self, Aead, NewAead},
+    ChaCha20Poly1305,
+};
 use hkdf::Hkdf;
 use hmac::{
-    crypto_mac::{MacError, MacResult},
+    crypto_mac::{generic_array::typenum::U32, MacError, MacResult},
     Hmac, Mac,
 };
 use scrypt::{errors::InvalidParams, scrypt as scrypt_inner, ScryptParams};

--- a/src/primitives/stream.rs
+++ b/src/primitives/stream.rs
@@ -2,8 +2,10 @@
 //!
 //! [STREAM]: https://eprint.iacr.org/2015/189.pdf
 
-use aead::{Aead, NewAead};
-use chacha20poly1305::ChaCha20Poly1305;
+use chacha20poly1305::{
+    aead::{Aead, NewAead},
+    ChaCha20Poly1305,
+};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use super::armor::ArmoredWriter;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Encryption and decryption routines for age.
 
-use getrandom::getrandom;
+use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, SecretString};
 use std::io::{self, Read, Seek, Write};
 
@@ -59,7 +59,7 @@ impl Encryptor {
         header.write(&mut output)?;
 
         let mut nonce = [0; 16];
-        getrandom(&mut nonce).expect("Should not fail");
+        OsRng.fill_bytes(&mut nonce);
         output.write_all(&nonce)?;
 
         let payload_key = hkdf(&nonce, PAYLOAD_KEY_LABEL, file_key.0.expose_secret());


### PR DESCRIPTION
- `Cargo.toml` is now annotated with the purpose of every dependency in the library.
- Some unnecessary direct dependencies have been dropped.

Kudos to [dochtman](https://www.reddit.com/r/rust/comments/egn81r/rage_a_simple_secure_and_modern_encryption_tool/fc80el0/) for the comments that prompted this refactor.