### PR TITLE
Re-enable the default identities file

### DIFF
--- a/src/bin/rage/error.rs
+++ b/src/bin/rage/error.rs
@@ -46,7 +46,7 @@ pub(crate) enum DecryptError {
     Age(age::Error),
     ArmorFlag,
     Io(io::Error),
-    MissingIdentities,
+    MissingIdentities(String),
     MixedIdentityAndPassphrase,
     PassphraseWithoutFileArgument,
     RecipientFlag,
@@ -74,9 +74,11 @@ impl fmt::Display for DecryptError {
                 write!(f, "Note that armored files are detected automatically.")
             }
             DecryptError::Io(e) => write!(f, "{}", e),
-            DecryptError::MissingIdentities => {
+            DecryptError::MissingIdentities(default_filename) => {
                 writeln!(f, "Missing identities.")?;
-                write!(f, "Did you forget to specify -i/--identity?")
+                writeln!(f, "Did you forget to specify -i/--identity?")?;
+                writeln!(f, "You can also store default identities in this file:")?;
+                write!(f, "    {}", default_filename)
             }
             DecryptError::MixedIdentityAndPassphrase => {
                 write!(f, "-i/--identity can't be used with -p/--passphrase")

--- a/src/bin/rage/main.rs
+++ b/src/bin/rage/main.rs
@@ -248,11 +248,9 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             Err(_) => return Ok(()),
         }
     } else {
-        if opts.identity.is_empty() {
-            return Err(error::DecryptError::MissingIdentities);
-        }
-
-        let identities = read_identities(opts.identity)?;
+        let identities = read_identities(opts.identity, |default_filename| {
+            error::DecryptError::MissingIdentities(default_filename.to_string())
+        })?;
 
         // Check for unsupported keys and alert the user
         for identity in &identities {


### PR DESCRIPTION
If a user does not specify -i/--identity and the default identities file
does not exist, the user is now informed about it.

Closes #39.