### PR TITLE
Parse and serialize unknown recipient lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ to 1.0.0 are beta releases.
   `bcrypt_pbkdf` parameters.
 - [Unix] `rage-keygen -o filename` now creates files with mode `600` (i.e. the
   output file is no longer world-readable).
+- Unknown recipient lines are now parsed and ignored during decryption, instead
+  of causing a hard failure.
 
 ## [0.1.1] - 2019-12-29
 ### Added

--- a/src/format/plugin.rs
+++ b/src/format/plugin.rs
@@ -1,0 +1,62 @@
+/// From the age spec:
+/// ```text
+/// Each recipient stanza starts with a line beginning with -> and its type name, followed
+/// by zero or more SP-separated arguments. The type name and the arguments are arbitrary
+/// strings. Unknown recipient types are ignored. The rest of the recipient stanza is a
+/// body of canonical base64 from RFC 4648 without padding wrapped at exactly 64 columns.
+/// ```
+#[derive(Debug)]
+pub(crate) struct RecipientLine {
+    tag: String,
+    args: Vec<String>,
+    body: Vec<u8>,
+}
+
+pub(super) mod read {
+    use nom::{
+        bytes::streaming::tag, character::streaming::newline, combinator::map,
+        multi::separated_nonempty_list, sequence::separated_pair, IResult,
+    };
+
+    use super::*;
+    use crate::util::read::{arbitrary_string, wrapped_encoded_data};
+
+    pub(crate) fn recipient_line(input: &[u8]) -> IResult<&[u8], RecipientLine> {
+        map(
+            separated_pair(
+                separated_nonempty_list(tag(" "), arbitrary_string),
+                newline,
+                wrapped_encoded_data,
+            ),
+            |(strings, body)| RecipientLine {
+                tag: strings[0].to_string(),
+                args: strings[1..].into_iter().map(|s| s.to_string()).collect(),
+                body,
+            },
+        )(input)
+    }
+}
+
+pub(super) mod write {
+    use cookie_factory::{combinator::string, multi::separated_list, sequence::tuple, SerializeFn};
+    use std::io::Write;
+    use std::iter;
+
+    use super::*;
+    use crate::util::write::wrapped_encoded_data;
+
+    pub(crate) fn recipient_line<'a, W: 'a + Write>(
+        r: &'a RecipientLine,
+    ) -> impl SerializeFn<W> + 'a {
+        tuple((
+            separated_list(
+                string(" "),
+                iter::once(&r.tag)
+                    .chain(r.args.iter())
+                    .map(|arg| string(arg)),
+            ),
+            string("\n"),
+            wrapped_encoded_data(&r.body),
+        ))
+    }
+}

--- a/src/format/ssh_rsa.rs
+++ b/src/format/ssh_rsa.rs
@@ -165,31 +165,12 @@ pub(super) mod write {
     use cookie_factory::{
         combinator::{slice, string},
         sequence::tuple,
-        SerializeFn, WriteContext,
+        SerializeFn,
     };
     use std::io::Write;
 
     use super::*;
-    use crate::util::write::encoded_data;
-
-    fn wrapped_encoded_data<'a, W: 'a + Write>(data: &[u8]) -> impl SerializeFn<W> + 'a {
-        let encoded = base64::encode_config(data, base64::STANDARD_NO_PAD);
-
-        move |mut w: WriteContext<W>| {
-            let mut s = encoded.as_str();
-
-            while s.len() > 64 {
-                let (l, r) = s.split_at(64);
-                w = string(l)(w)?;
-                if !r.is_empty() {
-                    w = string("\n")(w)?;
-                }
-                s = r;
-            }
-
-            string(s)(w)
-        }
-    }
+    use crate::util::write::{encoded_data, wrapped_encoded_data};
 
     pub(crate) fn recipient_line<'a, W: 'a + Write>(r: &RecipientLine) -> impl SerializeFn<W> + 'a {
         tuple((

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ pub(crate) const LINE_ENDING: &str = "\n";
 
 pub(crate) mod read {
     use nom::{
-        combinator::map_res,
+        combinator::{map, map_opt, map_res},
         error::{make_error, ErrorKind},
         multi::separated_nonempty_list,
         IResult,
@@ -79,6 +79,18 @@ pub(crate) mod read {
         }
     }
 
+    /// From the age specification:
+    /// ```text
+    /// ... an arbitrary string is a sequence of ASCII characters with values 33 to 126.
+    /// ```
+    pub(crate) fn arbitrary_string(input: &[u8]) -> IResult<&[u8], &str> {
+        use nom::bytes::streaming::take_while1;
+
+        map(take_while1(|c| c >= 33 && c <= 126), |bytes| {
+            std::str::from_utf8(bytes).expect("ASCII is valid UTF-8")
+        })(input)
+    }
+
     pub(crate) fn encoded_data<T: Copy + AsMut<[u8]>>(
         count: usize,
         template: T,
@@ -108,14 +120,90 @@ pub(crate) mod read {
             }
         }
     }
+
+    /// Returns the slice of input up to (but not including) the first CR or LF
+    /// character, if that slice is entirely Base64 characters
+    ///
+    /// # Errors
+    ///
+    /// - Returns Failure on an empty slice.
+    /// - Returns Incomplete(1) if a CR or LF is not found.
+    fn take_b64_line(config: base64::Config) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8]> {
+        move |input: &[u8]| {
+            let mut end = 0;
+            while end < input.len() {
+                let c = input[end];
+
+                if c == b'\r' || c == b'\n' {
+                    break;
+                }
+
+                // Substitute the character in twice after AA, so that padding
+                // characters will also be detected as a valid if allowed.
+                if base64::decode_config_slice(&[65, 65, c, c], config, &mut [0, 0, 0]).is_err() {
+                    end = 0;
+                    break;
+                }
+
+                end += 1;
+            }
+
+            if !input.is_empty() && end == 0 {
+                Err(nom::Err::Error(make_error(input, ErrorKind::Eof)))
+            } else if end < input.len() {
+                Ok((&input[end..], &input[..end]))
+            } else {
+                Err(nom::Err::Incomplete(nom::Needed::Size(1)))
+            }
+        }
+    }
+
+    pub(crate) fn wrapped_encoded_data(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
+        use nom::character::streaming::newline;
+
+        map_opt(
+            separated_nonempty_list(newline, take_b64_line(base64::STANDARD_NO_PAD)),
+            |chunks| {
+                // Enforce that the only chunk allowed to be shorter than 64 characters
+                // is the last chunk.
+                if chunks.iter().rev().skip(1).any(|s| s.len() != 64)
+                    || chunks.last().map(|s| s.len() > 64) == Some(true)
+                {
+                    None
+                } else {
+                    let data: Vec<u8> = chunks.into_iter().flatten().cloned().collect();
+                    base64::decode_config(&data, base64::STANDARD_NO_PAD).ok()
+                }
+            },
+        )(input)
+    }
 }
 
 pub(crate) mod write {
-    use cookie_factory::{combinator::string, SerializeFn};
+    use cookie_factory::{combinator::string, SerializeFn, WriteContext};
     use std::io::Write;
 
     pub(crate) fn encoded_data<W: Write>(data: &[u8]) -> impl SerializeFn<W> {
         let encoded = base64::encode_config(data, base64::STANDARD_NO_PAD);
         string(encoded)
+    }
+
+    pub(crate) fn wrapped_encoded_data<'a, W: 'a + Write>(data: &[u8]) -> impl SerializeFn<W> + 'a {
+        let encoded = base64::encode_config(data, base64::STANDARD_NO_PAD);
+
+        move |mut w: WriteContext<W>| {
+            let mut s = encoded.as_str();
+
+            while s.len() > 64 {
+                let (l, r) = s.split_at(64);
+                w = string(l)(w)?;
+                if !r.is_empty() {
+                    w = string("\n")(w)?;
+                }
+                s = r;
+            }
+
+            string(s)(w)
+        }
     }
 }


### PR DESCRIPTION
This ensures that unknown recipient lines are ignored during decryption,
rather than causing a hard decryption failure.

Closes #36.