### PR TITLE
Replace read_passphrase closure with Callbacks trait

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Added
+- `age::Callbacks`, which encapsulates any requests that might be necessary
+  during the decryption process.
+- `age::cli_common::UiCallbacks`, which implements `Callbacks` with requests to
+  the user via `age::cli_common::read_secret`.
+- `age::Decryptor::with_identities(Vec<Identity>)`
+- `age::Decryptor::with_identities_and_callbacks(Vec<Identity>, Box<dyn Callbacks>)`
+
 ### Changed
 - The CLI tools have been moved into the `rage` crate.
+- The `age::Decryptor::Keys` enum case has been renamed to `Identities` and
+  altered to store a `Box<dyn Callbacks>` internally.
+- `age::Decryptor::trial_decrypt` and `age::Decryptor::trial_decrypt_seekable`
+  both no longer take a `request_passphrase` argument.
 
 ### Fixed
 - Fixed several crashes in the armored format reader, found by fuzzing. The

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::PathBuf;
 
-use crate::keys::Identity;
+use crate::{keys::Identity, protocol::Callbacks};
 
 pub mod file_io;
 
@@ -76,6 +76,15 @@ pub fn read_secret(prompt: &str, confirm: Option<&str>) -> io::Result<SecretStri
             .allow_empty_password(true);
     }
     input.interact().map(SecretString::new)
+}
+
+/// Implementation of age callbacks that makes requests to the user via the UI.
+pub struct UiCallbacks;
+
+impl Callbacks for UiCallbacks {
+    fn request_passphrase(&self, description: &str) -> Option<SecretString> {
+        read_secret(description, None).ok()
+    }
 }
 
 /// A passphrase.

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -34,10 +34,10 @@
 //!
 //! // ... and decrypt the obtained ciphertext to the plaintext again.
 //! let decrypted = {
-//!     let decryptor = age::Decryptor::Keys(vec![key.into()]);
+//!     let decryptor = age::Decryptor::with_identities(vec![key.into()]);
 //!
 //!     let mut decrypted = vec![];
-//!     let mut reader = decryptor.trial_decrypt(&encrypted[..], |_| None)?;
+//!     let mut reader = decryptor.trial_decrypt(&encrypted[..])?;
 //!     reader.read_to_end(&mut decrypted);
 //!
 //!     decrypted
@@ -77,7 +77,7 @@
 //!     let decryptor = age::Decryptor::with_passphrase(Secret::new(passphrase.to_owned()));
 //!
 //!     let mut decrypted = vec![];
-//!     let mut reader = decryptor.trial_decrypt(&encrypted[..], |_| None)?;
+//!     let mut reader = decryptor.trial_decrypt(&encrypted[..])?;
 //!     reader.read_to_end(&mut decrypted);
 //!
 //!     decrypted
@@ -112,7 +112,7 @@ mod util;
 pub use error::Error;
 pub use keys::SecretKey;
 pub use primitives::stream::StreamReader;
-pub use protocol::{Decryptor, Encryptor};
+pub use protocol::{Callbacks, Decryptor, Encryptor};
 
 #[cfg(feature = "cli-common")]
 pub mod cli_common;

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -19,6 +19,20 @@ use crate::{
 const HEADER_KEY_LABEL: &[u8] = b"header";
 const PAYLOAD_KEY_LABEL: &[u8] = b"payload";
 
+/// Callbacks that might be triggered during decryption.
+pub trait Callbacks {
+    /// Requests a passphrase to decrypt a key.
+    fn request_passphrase(&self, description: &str) -> Option<SecretString>;
+}
+
+struct NoCallbacks;
+
+impl Callbacks for NoCallbacks {
+    fn request_passphrase(&self, _description: &str) -> Option<SecretString> {
+        None
+    }
+}
+
 /// Handles the various types of age encryption.
 pub enum Encryptor {
     /// Encryption to a list of recipients identified by keys.
@@ -70,8 +84,13 @@ impl Encryptor {
 
 /// Handles the various types of age decryption.
 pub enum Decryptor {
-    /// Trial decryption against a list of secret keys.
-    Keys(Vec<Identity>),
+    /// Trial decryption against a list of identities.
+    Identities {
+        /// The identities to use.
+        identities: Vec<Identity>,
+        /// A handler for any callbacks triggered by an `Identity`.
+        callbacks: Box<dyn Callbacks>,
+    },
     /// Decryption with a passphrase.
     Passphrase {
         /// The passphrase to decrypt with.
@@ -83,6 +102,31 @@ pub enum Decryptor {
 }
 
 impl Decryptor {
+    /// Creates a decryptor with a list of identities.
+    ///
+    /// The decryptor will have no callbacks registered, so it will be unable to use
+    /// identities that require e.g. a passphrase to decrypt.
+    pub fn with_identities(identities: Vec<Identity>) -> Self {
+        Decryptor::Identities {
+            identities,
+            callbacks: Box::new(NoCallbacks),
+        }
+    }
+
+    /// Creates a decryptor with a list of identities and a callback handler.
+    ///
+    /// The decryptor will have no callbacks registered, so it will be unable to use
+    /// identities that require e.g. a passphrase to decrypt.
+    pub fn with_identities_and_callbacks(
+        identities: Vec<Identity>,
+        callbacks: Box<dyn Callbacks>,
+    ) -> Self {
+        Decryptor::Identities {
+            identities,
+            callbacks,
+        }
+    }
+
     /// Creates a decryptor with a passphrase and the default max work factor.
     pub fn with_passphrase(passphrase: SecretString) -> Self {
         Decryptor::Passphrase {
@@ -91,16 +135,20 @@ impl Decryptor {
         }
     }
 
-    fn unwrap_file_key<P: Fn(&str) -> Option<SecretString> + Copy>(
-        &self,
-        line: &RecipientLine,
-        request_passphrase: P,
-    ) -> Result<Option<FileKey>, Error> {
+    fn unwrap_file_key(&self, line: &RecipientLine) -> Result<Option<FileKey>, Error> {
         match (self, line) {
-            (Decryptor::Keys(_), RecipientLine::Scrypt(_)) => Err(Error::MessageRequiresPassphrase),
-            (Decryptor::Keys(keys), _) => keys
+            (Decryptor::Identities { .. }, RecipientLine::Scrypt(_)) => {
+                Err(Error::MessageRequiresPassphrase)
+            }
+            (
+                Decryptor::Identities {
+                    identities,
+                    callbacks,
+                },
+                _,
+            ) => identities
                 .iter()
-                .find_map(|key| key.unwrap_file_key(line, request_passphrase))
+                .find_map(|key| key.unwrap_file_key(line, callbacks.as_ref()))
                 .transpose(),
             (
                 Decryptor::Passphrase {
@@ -119,11 +167,7 @@ impl Decryptor {
     /// to be decrypted before it can be used to decrypt the message.
     ///
     /// If successful, returns a reader that will provide the plaintext.
-    pub fn trial_decrypt<R: Read, P: Fn(&str) -> Option<SecretString> + Copy>(
-        &self,
-        input: R,
-        request_passphrase: P,
-    ) -> Result<impl Read, Error> {
+    pub fn trial_decrypt<R: Read>(&self, input: R) -> Result<impl Read, Error> {
         let mut input = ArmoredReader::from_reader(input);
 
         match Header::read(&mut input)? {
@@ -135,21 +179,19 @@ impl Decryptor {
                     .recipients
                     .iter()
                     .find_map(|r| {
-                        self.unwrap_file_key(r, request_passphrase)
-                            .transpose()
-                            .map(|res| {
-                                res.and_then(|file_key| {
-                                    // Verify the MAC
-                                    header.verify_mac(hkdf(
-                                        &[],
-                                        HEADER_KEY_LABEL,
-                                        file_key.0.expose_secret(),
-                                    ))?;
+                        self.unwrap_file_key(r).transpose().map(|res| {
+                            res.and_then(|file_key| {
+                                // Verify the MAC
+                                header.verify_mac(hkdf(
+                                    &[],
+                                    HEADER_KEY_LABEL,
+                                    file_key.0.expose_secret(),
+                                ))?;
 
-                                    // Return the payload key
-                                    Ok(hkdf(&nonce, PAYLOAD_KEY_LABEL, file_key.0.expose_secret()))
-                                })
+                                // Return the payload key
+                                Ok(hkdf(&nonce, PAYLOAD_KEY_LABEL, file_key.0.expose_secret()))
                             })
+                        })
                     })
                     .unwrap_or(Err(Error::NoMatchingKeys))
                     .map(|payload_key| Stream::decrypt(&payload_key, input))
@@ -164,10 +206,9 @@ impl Decryptor {
     /// to be decrypted before it can be used to decrypt the message.
     ///
     /// If successful, returns a seekable reader that will provide the plaintext.
-    pub fn trial_decrypt_seekable<R: Read + Seek, P: Fn(&str) -> Option<SecretString> + Copy>(
+    pub fn trial_decrypt_seekable<R: Read + Seek>(
         &self,
         mut input: R,
-        request_passphrase: P,
     ) -> Result<StreamReader<R>, Error> {
         match Header::read(&mut input)? {
             Header::V1(header) => {
@@ -178,21 +219,19 @@ impl Decryptor {
                     .recipients
                     .iter()
                     .find_map(|r| {
-                        self.unwrap_file_key(r, request_passphrase)
-                            .transpose()
-                            .map(|res| {
-                                res.and_then(|file_key| {
-                                    // Verify the MAC
-                                    header.verify_mac(hkdf(
-                                        &[],
-                                        HEADER_KEY_LABEL,
-                                        file_key.0.expose_secret(),
-                                    ))?;
+                        self.unwrap_file_key(r).transpose().map(|res| {
+                            res.and_then(|file_key| {
+                                // Verify the MAC
+                                header.verify_mac(hkdf(
+                                    &[],
+                                    HEADER_KEY_LABEL,
+                                    file_key.0.expose_secret(),
+                                ))?;
 
-                                    // Return the payload key
-                                    Ok(hkdf(&nonce, PAYLOAD_KEY_LABEL, file_key.0.expose_secret()))
-                                })
+                                // Return the payload key
+                                Ok(hkdf(&nonce, PAYLOAD_KEY_LABEL, file_key.0.expose_secret()))
                             })
+                        })
                     })
                     .unwrap_or(Err(Error::NoMatchingKeys))
                     .and_then(|payload_key| {
@@ -229,8 +268,8 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::Keys(sk);
-        let mut r = d.trial_decrypt(&encrypted[..], |_| None).unwrap();
+        let d = Decryptor::with_identities(sk);
+        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 
@@ -250,7 +289,7 @@ mod tests {
         }
 
         let d = Decryptor::with_passphrase(SecretString::new("passphrase".to_string()));
-        let mut r = d.trial_decrypt(&encrypted[..], |_| None).unwrap();
+        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 
@@ -274,8 +313,8 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::Keys(sk);
-        let mut r = d.trial_decrypt(&encrypted[..], |_| None).unwrap();
+        let d = Decryptor::with_identities(sk);
+        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 
@@ -298,8 +337,8 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::Keys(sk);
-        let mut r = d.trial_decrypt(&encrypted[..], |_| None).unwrap();
+        let d = Decryptor::with_identities(sk);
+        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -1,4 +1,4 @@
-use age::cli_common::{read_identities, read_secret};
+use age::cli_common::{read_identities, read_secret, UiCallbacks};
 use fuse_mt::FilesystemMT;
 use gumdrop::Options;
 use log::{error, info};
@@ -167,13 +167,13 @@ fn main() -> Result<(), Error> {
             }
         }
 
-        age::Decryptor::Keys(identities)
+        age::Decryptor::with_identities_and_callbacks(identities, Box::new(UiCallbacks))
     };
 
     info!("Decrypting {}", opts.filename);
     let file = File::open(opts.filename)?;
 
-    let stream = decryptor.trial_decrypt_seekable(file, |prompt| read_secret(prompt, None).ok())?;
+    let stream = decryptor.trial_decrypt_seekable(file)?;
 
     match opts.types.as_str() {
         "tar" => mount_fs(|| crate::tar::AgeTarFs::open(stream), opts.mountpoint),

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -1,7 +1,7 @@
 use age::{
     cli_common::{
         file_io, get_config_dir, read_identities, read_or_generate_passphrase, read_secret,
-        Passphrase,
+        Passphrase, UiCallbacks,
     },
     Format,
 };
@@ -293,14 +293,14 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             }
         }
 
-        age::Decryptor::Keys(identities)
+        age::Decryptor::with_identities_and_callbacks(identities, Box::new(UiCallbacks))
     };
 
     let input = file_io::InputReader::new(opts.input)?;
     let mut output =
         file_io::OutputWriter::new(opts.output, file_io::OutputFormat::Unknown, 0o666)?;
 
-    let mut input = decryptor.trial_decrypt(input, |prompt| read_secret(prompt, None).ok())?;
+    let mut input = decryptor.trial_decrypt(input)?;
 
     io::copy(&mut input, &mut output)?;
 


### PR DESCRIPTION
Passphrase decryption (which fetches a passphrase ahead of time) no longer requires a no-op closure, and similarly identity decryption can be implemented without support for encrypted identities. It is also easier to modify the Callbacks trait if we find other callbacks that are necessary.