### PR TITLE
Move age stanza parsing and serialization to new age-core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "age-core"
+version = "0.0.0"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ name = "age"
 version = "0.2.0"
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "age-core 0.0.0",
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcrypt-pbkdf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -80,6 +81,11 @@ dependencies = [
 [[package]]
 name = "age-core"
 version = "0.0.0"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie-factory 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "aho-corasick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "age",
+    "age-core",
     "rage",
 ]

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -9,3 +9,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+base64 = "0.11"
+cookie-factory = "0.3"
+nom = "5"

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "age-core"
+description = "[BETA] Common functions used across the age crates"
+version = "0.0.0"
+authors = ["Jack Grigg <thestr4d@gmail.com>"]
+repository = "https://github.com/str4d/rage"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]

--- a/age-core/README.md
+++ b/age-core/README.md
@@ -1,0 +1,23 @@
+# age-core Rust library
+
+This crate contains common functions used across the `age` crates.
+
+You are probably looking for the [`age`](https://crates.io/crates/age) crate
+itself.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -1,0 +1,152 @@
+/// From the age spec:
+/// ```text
+/// Each recipient stanza starts with a line beginning with -> and its type name, followed
+/// by zero or more SP-separated arguments. The type name and the arguments are arbitrary
+/// strings. Unknown recipient types are ignored. The rest of the recipient stanza is a
+/// body of canonical base64 from RFC 4648 without padding wrapped at exactly 64 columns.
+/// ```
+#[derive(Debug)]
+pub struct AgeStanza<'a> {
+    pub tag: &'a str,
+    pub args: Vec<&'a str>,
+    pub body: Vec<u8>,
+}
+
+pub mod read {
+    use nom::{
+        bytes::streaming::tag,
+        character::streaming::newline,
+        combinator::{map, map_opt},
+        error::{make_error, ErrorKind},
+        multi::separated_nonempty_list,
+        sequence::separated_pair,
+        IResult,
+    };
+
+    use super::AgeStanza;
+
+    /// From the age specification:
+    /// ```text
+    /// ... an arbitrary string is a sequence of ASCII characters with values 33 to 126.
+    /// ```
+    pub fn arbitrary_string(input: &[u8]) -> IResult<&[u8], &str> {
+        use nom::bytes::streaming::take_while1;
+
+        map(take_while1(|c| c >= 33 && c <= 126), |bytes| {
+            std::str::from_utf8(bytes).expect("ASCII is valid UTF-8")
+        })(input)
+    }
+
+    /// Returns the slice of input up to (but not including) the first LF
+    /// character, if that slice is entirely Base64 characters
+    ///
+    /// # Errors
+    ///
+    /// - Returns Failure on an empty slice.
+    /// - Returns Incomplete(1) if a LF is not found.
+    fn take_b64_line(config: base64::Config) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8]> {
+        move |input: &[u8]| {
+            let mut end = 0;
+            while end < input.len() {
+                let c = input[end];
+
+                if c == b'\n' {
+                    break;
+                }
+
+                // Substitute the character in twice after AA, so that padding
+                // characters will also be detected as a valid if allowed.
+                if base64::decode_config_slice(&[65, 65, c, c], config, &mut [0, 0, 0]).is_err() {
+                    end = 0;
+                    break;
+                }
+
+                end += 1;
+            }
+
+            if !input.is_empty() && end == 0 {
+                Err(nom::Err::Error(make_error(input, ErrorKind::Eof)))
+            } else if end < input.len() {
+                Ok((&input[end..], &input[..end]))
+            } else {
+                Err(nom::Err::Incomplete(nom::Needed::Size(1)))
+            }
+        }
+    }
+
+    fn wrapped_encoded_data(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
+        map_opt(
+            separated_nonempty_list(newline, take_b64_line(base64::STANDARD_NO_PAD)),
+            |chunks| {
+                // Enforce that the only chunk allowed to be shorter than 64 characters
+                // is the last chunk.
+                if chunks.iter().rev().skip(1).any(|s| s.len() != 64)
+                    || chunks.last().map(|s| s.len() > 64) == Some(true)
+                {
+                    None
+                } else {
+                    let data: Vec<u8> = chunks.into_iter().flatten().cloned().collect();
+                    base64::decode_config(&data, base64::STANDARD_NO_PAD).ok()
+                }
+            },
+        )(input)
+    }
+
+    /// Reads an age stanza.
+    pub fn age_stanza<'a>(input: &'a [u8]) -> IResult<&'a [u8], AgeStanza<'a>> {
+        map(
+            separated_pair(
+                separated_nonempty_list(tag(" "), arbitrary_string),
+                newline,
+                wrapped_encoded_data,
+            ),
+            |(mut args, body)| {
+                let tag = args.remove(0);
+                AgeStanza { tag, args, body }
+            },
+        )(input)
+    }
+}
+
+pub mod write {
+    use cookie_factory::{
+        combinator::string, multi::separated_list, sequence::tuple, SerializeFn, WriteContext,
+    };
+    use std::io::Write;
+    use std::iter;
+
+    fn wrapped_encoded_data<'a, W: 'a + Write>(data: &[u8]) -> impl SerializeFn<W> + 'a {
+        let encoded = base64::encode_config(data, base64::STANDARD_NO_PAD);
+
+        move |mut w: WriteContext<W>| {
+            let mut s = encoded.as_str();
+
+            while s.len() > 64 {
+                let (l, r) = s.split_at(64);
+                w = string(l)(w)?;
+                if !r.is_empty() {
+                    w = string("\n")(w)?;
+                }
+                s = r;
+            }
+
+            string(s)(w)
+        }
+    }
+
+    /// Writes an age stanza.
+    pub fn age_stanza<'a, W: 'a + Write>(
+        tag: &'a str,
+        args: &'a [&'a str],
+        body: &'a [u8],
+    ) -> impl SerializeFn<W> + 'a {
+        tuple((
+            separated_list(
+                string(" "),
+                iter::once(tag).chain(args.iter().copied()).map(string),
+            ),
+            string("\n"),
+            wrapped_encoded_data(body),
+        ))
+    }
+}

--- a/age-core/src/lib.rs
+++ b/age-core/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/age-core/src/lib.rs
+++ b/age-core/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub mod format;

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -31,6 +31,7 @@ to 1.0.0 are beta releases.
 ### Fixed
 - Fixed several crashes in the armored format reader, found by fuzzing. The
   reader also now correctly enforces a canonical armor marker and line lengths.
+- Recipient stanzas with empty bodies are correctly parsed.
 
 ## [0.2.0] - 2020-01-10
 ### Added

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
+age-core = { version = "0.0.0", path = "../age-core" }
+
 # Dependencies required by the age specification:
 # - Base64 from RFC 4648
 base64 = "0.11"

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -283,6 +283,7 @@ m/uPLMQdlIkiOOdbsrE6tFesRLZNHAYspeRKI9MJ++Xg9i7rutU34ZM+1BL6KgZf
 J9FSm+GFHiVWpr1MfYCo/w
 -> ssh-ed25519 BjH7FA RO+wV4kbbl4NtSmp56lQcfRdRp3dEFpdQmWkaoiw6lY
 51eEu5Oo2JYAG7OU4oamH03FDRP18/GnzeCrY7Z+sa8
+-> some-empty-body-recipient BjH7FA 37 mhir0Q
 -> some-other-recipient mhir0Q BjH7FA 37
 m/uPLMQdlIkiOOdbsrE6tFesRLZNHAYspeRKI9MJ++Xg9i7rutU34ZM+1BL6KgZf
 J9FSm+GFHiVWpr1MfYCo/w

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -16,20 +16,6 @@ const V1_MAGIC: &[u8] = b"v1";
 const RECIPIENT_TAG: &[u8] = b"-> ";
 const MAC_TAG: &[u8] = b"---";
 
-/// From the age spec:
-/// ```text
-/// Each recipient stanza starts with a line beginning with -> and its type name, followed
-/// by zero or more SP-separated arguments. The type name and the arguments are arbitrary
-/// strings. Unknown recipient types are ignored. The rest of the recipient stanza is a
-/// body of canonical base64 from RFC 4648 without padding wrapped at exactly 64 columns.
-/// ```
-#[derive(Debug)]
-pub(crate) struct AgeStanza<'a> {
-    tag: &'a str,
-    args: Vec<&'a str>,
-    body: Vec<u8>,
-}
-
 #[derive(Debug)]
 pub(crate) enum RecipientLine {
     X25519(x25519::RecipientLine),
@@ -142,32 +128,19 @@ pub(crate) enum Header {
 }
 
 mod read {
+    use age_core::format::read::{age_stanza, arbitrary_string};
     use nom::{
         branch::alt,
         bytes::streaming::{tag, take},
         character::streaming::newline,
         combinator::{map, map_opt},
         multi::separated_nonempty_list,
-        sequence::{pair, preceded, separated_pair, terminated},
+        sequence::{pair, preceded, terminated},
         IResult,
     };
 
     use super::*;
-    use crate::util::read::{arbitrary_string, base64_arg, wrapped_encoded_data};
-
-    fn age_stanza<'a>(input: &'a [u8]) -> IResult<&'a [u8], AgeStanza<'a>> {
-        map(
-            separated_pair(
-                separated_nonempty_list(tag(" "), arbitrary_string),
-                newline,
-                wrapped_encoded_data,
-            ),
-            |(mut args, body)| {
-                let tag = args.remove(0);
-                AgeStanza { tag, args, body }
-            },
-        )(input)
-    }
+    use crate::util::read::base64_arg;
 
     fn recipient_line(input: &[u8]) -> IResult<&[u8], RecipientLine> {
         preceded(

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -24,7 +24,7 @@ const MAC_TAG: &[u8] = b"---";
 /// body of canonical base64 from RFC 4648 without padding wrapped at exactly 64 columns.
 /// ```
 #[derive(Debug)]
-pub(crate) struct RecipientStanza<'a> {
+pub(crate) struct AgeStanza<'a> {
     tag: &'a str,
     args: Vec<&'a str>,
     body: Vec<u8>,
@@ -155,7 +155,7 @@ mod read {
     use super::*;
     use crate::util::read::{arbitrary_string, base64_arg, wrapped_encoded_data};
 
-    fn recipient_stanza<'a>(input: &'a [u8]) -> IResult<&'a [u8], RecipientStanza<'a>> {
+    fn age_stanza<'a>(input: &'a [u8]) -> IResult<&'a [u8], AgeStanza<'a>> {
         map(
             separated_pair(
                 separated_nonempty_list(tag(" "), arbitrary_string),
@@ -164,7 +164,7 @@ mod read {
             ),
             |(mut args, body)| {
                 let tag = args.remove(0);
-                RecipientStanza { tag, args, body }
+                AgeStanza { tag, args, body }
             },
         )(input)
     }
@@ -172,7 +172,7 @@ mod read {
     fn recipient_line(input: &[u8]) -> IResult<&[u8], RecipientLine> {
         preceded(
             tag(RECIPIENT_TAG),
-            map_opt(recipient_stanza, |stanza| match stanza.tag {
+            map_opt(age_stanza, |stanza| match stanza.tag {
                 x25519::X25519_RECIPIENT_TAG => {
                     x25519::RecipientLine::from_stanza(stanza).map(RecipientLine::X25519)
                 }

--- a/age/src/format/plugin.rs
+++ b/age/src/format/plugin.rs
@@ -1,4 +1,4 @@
-use super::RecipientStanza;
+use super::AgeStanza;
 
 #[derive(Debug)]
 pub(crate) struct RecipientLine {
@@ -8,7 +8,7 @@ pub(crate) struct RecipientLine {
 }
 
 impl RecipientLine {
-    pub(super) fn from_stanza(stanza: RecipientStanza<'_>) -> Self {
+    pub(super) fn from_stanza(stanza: AgeStanza<'_>) -> Self {
         RecipientLine {
             tag: stanza.tag.to_string(),
             args: stanza.args.into_iter().map(|s| s.to_string()).collect(),

--- a/age/src/format/scrypt.rs
+++ b/age/src/format/scrypt.rs
@@ -3,7 +3,7 @@ use secrecy::{ExposeSecret, Secret, SecretString};
 use std::convert::TryInto;
 use std::time::{Duration, SystemTime};
 
-use super::RecipientStanza;
+use super::AgeStanza;
 use crate::{
     error::Error,
     keys::FileKey,
@@ -52,7 +52,7 @@ pub(crate) struct RecipientLine {
 }
 
 impl RecipientLine {
-    pub(super) fn from_stanza(stanza: RecipientStanza<'_>) -> Option<Self> {
+    pub(super) fn from_stanza(stanza: AgeStanza<'_>) -> Option<Self> {
         if stanza.tag != SCRYPT_RECIPIENT_TAG {
             return None;
         }

--- a/age/src/format/scrypt.rs
+++ b/age/src/format/scrypt.rs
@@ -1,9 +1,9 @@
+use age_core::format::AgeStanza;
 use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::convert::TryInto;
 use std::time::{Duration, SystemTime};
 
-use super::AgeStanza;
 use crate::{
     error::Error,
     keys::FileKey,
@@ -128,19 +128,20 @@ impl RecipientLine {
 }
 
 pub(super) mod write {
-    use cookie_factory::{combinator::string, sequence::tuple, SerializeFn};
+    use age_core::format::write::age_stanza;
+    use cookie_factory::{SerializeFn, WriteContext};
     use std::io::Write;
 
     use super::*;
-    use crate::util::write::encoded_data;
 
-    pub(crate) fn recipient_line<'a, W: 'a + Write>(r: &RecipientLine) -> impl SerializeFn<W> + 'a {
-        tuple((
-            string(SCRYPT_RECIPIENT_TAG),
-            string(" "),
-            encoded_data(&r.salt),
-            string(format!(" {}{}", r.log_n, "\n")),
-            encoded_data(&r.encrypted_file_key),
-        ))
+    pub(crate) fn recipient_line<'a, W: 'a + Write>(
+        r: &'a RecipientLine,
+    ) -> impl SerializeFn<W> + 'a {
+        move |w: WriteContext<W>| {
+            let encoded_salt = base64::encode_config(&r.salt, base64::STANDARD_NO_PAD);
+            let args = &[encoded_salt.as_str(), &format!("{}", r.log_n)];
+            let writer = age_stanza(SCRYPT_RECIPIENT_TAG, args, &r.encrypted_file_key);
+            writer(w)
+        }
     }
 }

--- a/age/src/format/ssh_ed25519.rs
+++ b/age/src/format/ssh_ed25519.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha256, Sha512};
 use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
-use super::RecipientStanza;
+use super::AgeStanza;
 use crate::{
     error::Error,
     format::x25519::ENCRYPTED_FILE_KEY_BYTES,
@@ -33,7 +33,7 @@ pub(crate) struct RecipientLine {
 }
 
 impl RecipientLine {
-    pub(super) fn from_stanza(stanza: RecipientStanza<'_>) -> Option<Self> {
+    pub(super) fn from_stanza(stanza: AgeStanza<'_>) -> Option<Self> {
         if stanza.tag != SSH_ED25519_RECIPIENT_TAG {
             return None;
         }

--- a/age/src/format/ssh_ed25519.rs
+++ b/age/src/format/ssh_ed25519.rs
@@ -1,3 +1,4 @@
+use age_core::format::AgeStanza;
 use curve25519_dalek::edwards::EdwardsPoint;
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, Secret};
@@ -5,7 +6,6 @@ use sha2::{Digest, Sha256, Sha512};
 use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
-use super::AgeStanza;
 use crate::{
     error::Error,
     format::x25519::ENCRYPTED_FILE_KEY_BYTES,
@@ -136,21 +136,21 @@ impl RecipientLine {
 }
 
 pub(super) mod write {
-    use cookie_factory::{combinator::string, sequence::tuple, SerializeFn};
+    use age_core::format::write::age_stanza;
+    use cookie_factory::{SerializeFn, WriteContext};
     use std::io::Write;
 
     use super::*;
-    use crate::util::write::encoded_data;
 
-    pub(crate) fn recipient_line<'a, W: 'a + Write>(r: &RecipientLine) -> impl SerializeFn<W> + 'a {
-        tuple((
-            string(SSH_ED25519_RECIPIENT_TAG),
-            string(" "),
-            encoded_data(&r.tag),
-            string(" "),
-            encoded_data(r.rest.epk.as_bytes()),
-            string("\n"),
-            encoded_data(&r.rest.encrypted_file_key),
-        ))
+    pub(crate) fn recipient_line<'a, W: 'a + Write>(
+        r: &'a RecipientLine,
+    ) -> impl SerializeFn<W> + 'a {
+        move |w: WriteContext<W>| {
+            let encoded_tag = base64::encode_config(&r.tag, base64::STANDARD_NO_PAD);
+            let encoded_epk = base64::encode_config(r.rest.epk.as_bytes(), base64::STANDARD_NO_PAD);
+            let args = &[encoded_tag.as_str(), encoded_epk.as_str()];
+            let writer = age_stanza(SSH_ED25519_RECIPIENT_TAG, args, &r.rest.encrypted_file_key);
+            writer(w)
+        }
     }
 }

--- a/age/src/format/ssh_rsa.rs
+++ b/age/src/format/ssh_rsa.rs
@@ -1,9 +1,9 @@
+use age_core::format::AgeStanza;
 use rand::rngs::OsRng;
 use rsa::{RSAPrivateKey, RSAPublicKey};
 use secrecy::{ExposeSecret, Secret};
 use sha2::{Digest, Sha256};
 
-use super::AgeStanza;
 use crate::{error::Error, keys::FileKey, util::read::base64_arg};
 
 pub(super) const SSH_RSA_RECIPIENT_TAG: &str = "ssh-rsa";
@@ -91,19 +91,20 @@ impl RecipientLine {
 }
 
 pub(super) mod write {
-    use cookie_factory::{combinator::string, sequence::tuple, SerializeFn};
+    use age_core::format::write::age_stanza;
+    use cookie_factory::{SerializeFn, WriteContext};
     use std::io::Write;
 
     use super::*;
-    use crate::util::write::{encoded_data, wrapped_encoded_data};
 
-    pub(crate) fn recipient_line<'a, W: 'a + Write>(r: &RecipientLine) -> impl SerializeFn<W> + 'a {
-        tuple((
-            string(SSH_RSA_RECIPIENT_TAG),
-            string(" "),
-            encoded_data(&r.tag),
-            string("\n"),
-            wrapped_encoded_data(&r.encrypted_file_key),
-        ))
+    pub(crate) fn recipient_line<'a, W: 'a + Write>(
+        r: &'a RecipientLine,
+    ) -> impl SerializeFn<W> + 'a {
+        move |w: WriteContext<W>| {
+            let encoded_tag = base64::encode_config(&r.tag, base64::STANDARD_NO_PAD);
+            let args = &[encoded_tag.as_str()];
+            let writer = age_stanza(SSH_RSA_RECIPIENT_TAG, args, &r.encrypted_file_key);
+            writer(w)
+        }
     }
 }

--- a/age/src/format/ssh_rsa.rs
+++ b/age/src/format/ssh_rsa.rs
@@ -3,7 +3,7 @@ use rsa::{RSAPrivateKey, RSAPublicKey};
 use secrecy::{ExposeSecret, Secret};
 use sha2::{Digest, Sha256};
 
-use super::RecipientStanza;
+use super::AgeStanza;
 use crate::{error::Error, keys::FileKey, util::read::base64_arg};
 
 pub(super) const SSH_RSA_RECIPIENT_TAG: &str = "ssh-rsa";
@@ -25,7 +25,7 @@ pub(crate) struct RecipientLine {
 }
 
 impl RecipientLine {
-    pub(super) fn from_stanza(stanza: RecipientStanza<'_>) -> Option<Self> {
+    pub(super) fn from_stanza(stanza: AgeStanza<'_>) -> Option<Self> {
         if stanza.tag != SSH_RSA_RECIPIENT_TAG {
             return None;
         }

--- a/age/src/format/x25519.rs
+++ b/age/src/format/x25519.rs
@@ -3,7 +3,7 @@ use secrecy::{ExposeSecret, Secret};
 use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
-use super::RecipientStanza;
+use super::AgeStanza;
 use crate::{
     error::Error,
     keys::FileKey,
@@ -24,7 +24,7 @@ pub(crate) struct RecipientLine {
 }
 
 impl RecipientLine {
-    pub(super) fn from_stanza(stanza: RecipientStanza<'_>) -> Option<Self> {
+    pub(super) fn from_stanza(stanza: AgeStanza<'_>) -> Option<Self> {
         if stanza.tag != X25519_RECIPIENT_TAG {
             return None;
         }

--- a/age/src/format/x25519.rs
+++ b/age/src/format/x25519.rs
@@ -1,9 +1,9 @@
+use age_core::format::AgeStanza;
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, Secret};
 use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
-use super::AgeStanza;
 use crate::{
     error::Error,
     keys::FileKey,
@@ -82,20 +82,21 @@ impl RecipientLine {
 }
 
 pub(super) mod write {
-    use cookie_factory::{combinator::string, sequence::tuple, SerializeFn};
+    use age_core::format::write::age_stanza;
+    use cookie_factory::{SerializeFn, WriteContext};
     use std::io::Write;
 
-    use super::*;
-    use crate::util::write::encoded_data;
+    use super::{RecipientLine, X25519_RECIPIENT_TAG};
 
-    pub(crate) fn recipient_line<'a, W: 'a + Write>(r: &RecipientLine) -> impl SerializeFn<W> + 'a {
-        tuple((
-            string(X25519_RECIPIENT_TAG),
-            string(" "),
-            encoded_data(r.epk.as_bytes()),
-            string("\n"),
-            encoded_data(&r.encrypted_file_key),
-        ))
+    pub(crate) fn recipient_line<'a, W: 'a + Write>(
+        r: &'a RecipientLine,
+    ) -> impl SerializeFn<W> + 'a {
+        move |w: WriteContext<W>| {
+            let encoded_epk = base64::encode_config(r.epk.as_bytes(), base64::STANDARD_NO_PAD);
+            let args = &[encoded_epk.as_str()];
+            let writer = age_stanza(X25519_RECIPIENT_TAG, args, &r.encrypted_file_key);
+            writer(w)
+        }
     }
 }
 

--- a/age/src/util.rs
+++ b/age/src/util.rs
@@ -5,7 +5,7 @@ pub(crate) const LINE_ENDING: &str = "\n";
 
 pub(crate) mod read {
     use nom::{
-        combinator::{map, map_opt, map_res},
+        combinator::map_res,
         error::{make_error, ErrorKind},
         multi::separated_nonempty_list,
         IResult,
@@ -79,18 +79,6 @@ pub(crate) mod read {
         }
     }
 
-    /// From the age specification:
-    /// ```text
-    /// ... an arbitrary string is a sequence of ASCII characters with values 33 to 126.
-    /// ```
-    pub(crate) fn arbitrary_string(input: &[u8]) -> IResult<&[u8], &str> {
-        use nom::bytes::streaming::take_while1;
-
-        map(take_while1(|c| c >= 33 && c <= 126), |bytes| {
-            std::str::from_utf8(bytes).expect("ASCII is valid UTF-8")
-        })(input)
-    }
-
     pub(crate) fn base64_arg<A: AsRef<[u8]>, B: AsMut<[u8]>>(arg: &A, mut buf: B) -> Option<B> {
         if arg.as_ref().len() != ((4 * buf.as_mut().len()) + 2) / 3 {
             return None;
@@ -101,90 +89,14 @@ pub(crate) mod read {
             Err(_) => None,
         }
     }
-
-    /// Returns the slice of input up to (but not including) the first LF
-    /// character, if that slice is entirely Base64 characters
-    ///
-    /// # Errors
-    ///
-    /// - Returns Failure on an empty slice.
-    /// - Returns Incomplete(1) if a LF is not found.
-    fn take_b64_line(config: base64::Config) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8]> {
-        move |input: &[u8]| {
-            let mut end = 0;
-            while end < input.len() {
-                let c = input[end];
-
-                if c == b'\n' {
-                    break;
-                }
-
-                // Substitute the character in twice after AA, so that padding
-                // characters will also be detected as a valid if allowed.
-                if base64::decode_config_slice(&[65, 65, c, c], config, &mut [0, 0, 0]).is_err() {
-                    end = 0;
-                    break;
-                }
-
-                end += 1;
-            }
-
-            if !input.is_empty() && end == 0 {
-                Err(nom::Err::Error(make_error(input, ErrorKind::Eof)))
-            } else if end < input.len() {
-                Ok((&input[end..], &input[..end]))
-            } else {
-                Err(nom::Err::Incomplete(nom::Needed::Size(1)))
-            }
-        }
-    }
-
-    pub(crate) fn wrapped_encoded_data(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
-        use nom::character::streaming::newline;
-
-        map_opt(
-            separated_nonempty_list(newline, take_b64_line(base64::STANDARD_NO_PAD)),
-            |chunks| {
-                // Enforce that the only chunk allowed to be shorter than 64 characters
-                // is the last chunk.
-                if chunks.iter().rev().skip(1).any(|s| s.len() != 64)
-                    || chunks.last().map(|s| s.len() > 64) == Some(true)
-                {
-                    None
-                } else {
-                    let data: Vec<u8> = chunks.into_iter().flatten().cloned().collect();
-                    base64::decode_config(&data, base64::STANDARD_NO_PAD).ok()
-                }
-            },
-        )(input)
-    }
 }
 
 pub(crate) mod write {
-    use cookie_factory::{combinator::string, SerializeFn, WriteContext};
+    use cookie_factory::{combinator::string, SerializeFn};
     use std::io::Write;
 
     pub(crate) fn encoded_data<W: Write>(data: &[u8]) -> impl SerializeFn<W> {
         let encoded = base64::encode_config(data, base64::STANDARD_NO_PAD);
         string(encoded)
-    }
-
-    pub(crate) fn wrapped_encoded_data<'a, W: 'a + Write>(data: &[u8]) -> impl SerializeFn<W> + 'a {
-        let encoded = base64::encode_config(data, base64::STANDARD_NO_PAD);
-
-        move |mut w: WriteContext<W>| {
-            let mut s = encoded.as_str();
-
-            while s.len() > 64 {
-                let (l, r) = s.split_at(64);
-                w = string(l)(w)?;
-                if !r.is_empty() {
-                    w = string("\n")(w)?;
-                }
-                s = r;
-            }
-
-            string(s)(w)
-        }
     }
 }


### PR DESCRIPTION
`age-core` will be the home for low-level age components that will be reused by e.g. the plugin system (plugins themselves will not need the entire `age` crate).

Other changes in this PR:
- Serialization of age stanzas has been refactored to use a common format function.
- The age stanza parser is now significantly simpler.
- Stanzas with empty bodies are correctly parsed.

Part of #45.