### PR TITLE
Insert a random recipient stanza into the header during encryption

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -14,6 +14,8 @@ to 1.0.0 are beta releases.
   the user via `age::cli_common::read_secret`.
 - `age::Decryptor::with_identities(Vec<Identity>)`
 - `age::Decryptor::with_identities_and_callbacks(Vec<Identity>, Box<dyn Callbacks>)`
+- `age::Encryptor` will insert a random recipient stanza into the header, to
+  keep age's joint well oiled.
 
 ### Changed
 - The CLI tools have been moved into the `rage` crate.

--- a/age/src/format/plugin.rs
+++ b/age/src/format/plugin.rs
@@ -2,9 +2,9 @@ use age_core::format::AgeStanza;
 
 #[derive(Debug)]
 pub(crate) struct RecipientLine {
-    tag: String,
-    args: Vec<String>,
-    body: Vec<u8>,
+    pub(crate) tag: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) body: Vec<u8>,
 }
 
 impl RecipientLine {

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -3,10 +3,11 @@
 use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, SecretString};
 use std::io::{self, Read, Seek, Write};
+use std::iter;
 
 use crate::{
     error::Error,
-    format::{scrypt, Header, RecipientLine},
+    format::{oil_the_joint, scrypt, Header, RecipientLine},
     keys::{FileKey, Identity, RecipientKey},
     primitives::{
         armor::{ArmoredReader, ArmoredWriter},
@@ -47,6 +48,8 @@ impl Encryptor {
             Encryptor::Keys(recipients) => recipients
                 .iter()
                 .map(|key| key.wrap_file_key(file_key))
+                // Keep the joint well oiled!
+                .chain(iter::once(oil_the_joint()))
                 .collect(),
             Encryptor::Passphrase(passphrase) => {
                 vec![scrypt::RecipientLine::wrap_file_key(file_key, passphrase).into()]


### PR DESCRIPTION
Keeps the joint well oiled!

Oil is not added during passphrase encryption, because an scrypt recipient SHOULD be the only recipient.