### PR TITLE
Switch to c2-chacha crate for ChaCha20-IETF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,8 @@ dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bcrypt-pbkdf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chacha20poly1305 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chacha20poly1305 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie-factory 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -298,7 +299,9 @@ name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,12 +333,13 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chacha20 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "poly1305 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1870,7 +1874,7 @@ dependencies = [
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chacha20 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bea8b86bdf2f2b18a0f28fbfed740ee395e6ba1785b4b7123c021172eaab8ef9"
-"checksum chacha20poly1305 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d7c7def9c4e6f11a5b7525585853135689865907ca3c4c34e0a4b252fd50dd0"
+"checksum chacha20poly1305 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "48901293601228db2131606f741db33561f7576b5d19c99cd66222380a7dc863"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)" = "<none>"

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -21,7 +21,8 @@ age-core = { version = "0.3.1", path = "../age-core" }
 base64 = "0.11"
 
 # - ChaCha20-Poly1305 from RFC 7539
-chacha20poly1305 = "0.3"
+c2-chacha = "0.2"
+chacha20poly1305 = "0.4"
 
 # - X25519 from RFC 7748
 x25519-dalek = "0.6"

--- a/age/src/primitives/stream.rs
+++ b/age/src/primitives/stream.rs
@@ -4,7 +4,7 @@
 
 use chacha20poly1305::{
     aead::{Aead, NewAead},
-    ChaCha20Poly1305,
+    ChaChaPoly1305,
 };
 use secrecy::{ExposeSecret, SecretVec};
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -20,14 +20,14 @@ const ENCRYPTED_CHUNK_SIZE: usize = CHUNK_SIZE + TAG_SIZE;
 /// Instantiated with ChaCha20-Poly1305 in 64KiB chunks, and a nonce structure of 11 bytes
 /// of big endian counter, and 1 byte of last block flag (0x00 / 0x01).
 pub struct Stream {
-    aead: ChaCha20Poly1305,
+    aead: ChaChaPoly1305<c2_chacha::Ietf>,
     nonce: [u8; 12],
 }
 
 impl Stream {
     fn new(key: &[u8; 32]) -> Self {
         Stream {
-            aead: ChaCha20Poly1305::new((*key).into()),
+            aead: ChaChaPoly1305::new((*key).into()),
             nonce: [0; 12],
         }
     }


### PR DESCRIPTION
Improves encryption throughput by around 60% over standard, and around 10% when compiled with the AVX2 flag, because c2-chacha uses AVX2 when available.

Part of #57.