### PR TITLE
Replace chacha20 with c2-chacha in all primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,21 +324,11 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "chacha20"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "chacha20poly1305"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chacha20 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "poly1305 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1852,7 +1842,6 @@ dependencies = [
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chacha20 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bea8b86bdf2f2b18a0f28fbfed740ee395e6ba1785b4b7123c021172eaab8ef9"
 "checksum chacha20poly1305 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "48901293601228db2131606f741db33561f7576b5d19c99cd66222380a7dc863"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.11"
 
 # - ChaCha20-Poly1305 from RFC 7539
 c2-chacha = "0.2"
-chacha20poly1305 = "0.4"
+chacha20poly1305 = { version = "0.4", default-features = false, features = ["alloc"] }
 
 # - X25519 from RFC 7748
 x25519-dalek = "0.6"

--- a/age/src/primitives.rs
+++ b/age/src/primitives.rs
@@ -2,7 +2,7 @@
 
 use chacha20poly1305::{
     aead::{self, Aead, NewAead},
-    ChaCha20Poly1305,
+    ChaChaPoly1305,
 };
 use hkdf::Hkdf;
 use hmac::{
@@ -22,7 +22,7 @@ pub(crate) mod stream;
 ///
 /// [RFC 7539]: https://tools.ietf.org/html/rfc7539
 pub(crate) fn aead_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
-    let c = ChaCha20Poly1305::new((*key).into());
+    let c = ChaChaPoly1305::<c2_chacha::Ietf>::new((*key).into());
     c.encrypt(&[0; 12].into(), plaintext)
         .expect("we won't overflow the ChaCha20 block counter")
 }
@@ -33,7 +33,7 @@ pub(crate) fn aead_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
 ///
 /// [RFC 7539]: https://tools.ietf.org/html/rfc7539
 pub(crate) fn aead_decrypt(key: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, aead::Error> {
-    let c = ChaCha20Poly1305::new((*key).into());
+    let c = ChaChaPoly1305::<c2_chacha::Ietf>::new((*key).into());
     c.decrypt(&[0; 12].into(), ciphertext)
 }
 


### PR DESCRIPTION
This removes the `chacha20` crate from our dependency tree.