### PR TITLE
impl Seek for ArmoredReader

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Changed
+- `age::Decryptor::trial_decrypt` returns `StreamReader<R>` instead of
+  `impl Read`, enabling it to handle seekable readers.
+
+### Removed
+- `age::Decryptor::trial_decrypt_seekable` (replaced by
+  `age::Decryptor::trial_decrypt`).
+
 ### Fixed
 - Key files with Windows line endings are now correctly parsed.
 

--- a/age/src/primitives/armor.rs
+++ b/age/src/primitives/armor.rs
@@ -137,7 +137,7 @@ enum StartPos {
     Explicit(u64),
 }
 
-pub(crate) struct ArmoredReader<R: Read> {
+pub struct ArmoredReader<R: Read> {
     inner: BufReader<R>,
     start: StartPos,
     is_armored: Option<bool>,

--- a/age/src/primitives/stream.rs
+++ b/age/src/primitives/stream.rs
@@ -54,35 +54,14 @@ impl Stream {
     /// random nonce.
     ///
     /// [`HKDF`]: crate::primitives::hkdf
-    pub fn decrypt<R: Read>(key: &[u8; 32], inner: R) -> impl Read {
+    pub(crate) fn decrypt<R: Read>(key: &[u8; 32], inner: R) -> StreamReader<R> {
         StreamReader {
             stream: Self::new(key),
             inner,
-            start: 0,
+            start: StartPos::Implicit(0),
             cur_plaintext_pos: 0,
             chunk: None,
         }
-    }
-
-    /// Wraps `STREAM` decryption under the given `key` around a seekable reader.
-    ///
-    /// `key` must **never** be repeated across multiple streams. In `age` this is
-    /// achieved by deriving the key with [`HKDF`] from both a random file key and a
-    /// random nonce.
-    ///
-    /// [`HKDF`]: crate::primitives::hkdf
-    pub fn decrypt_seekable<R: Read + Seek>(
-        key: &[u8; 32],
-        mut inner: R,
-    ) -> io::Result<StreamReader<R>> {
-        let start = inner.seek(SeekFrom::Current(0))?;
-        Ok(StreamReader {
-            stream: Self::new(key),
-            inner,
-            start,
-            cur_plaintext_pos: 0,
-            chunk: None,
-        })
     }
 
     fn set_counter(&mut self, val: u64) {
@@ -197,13 +176,54 @@ impl<W: Write> Write for StreamWriter<W> {
     }
 }
 
+/// The position in the underlying reader corresponding to the start of the stream.
+///
+/// To impl Seek for StreamReader, we need to know the point in the reader corresponding
+/// to the first byte of the stream. But we can't query the reader for its current
+/// position without having a specific constructor for `R: Read + Seek`, which makes the
+/// higher-level API more complex. Instead, we count the number of bytes that have been
+/// read from the reader until we first need to seek, and then inside `impl Seek` we can
+/// query the reader's current position and figure out where the start was.
+enum StartPos {
+    /// An offset that we can subtract from the current position.
+    Implicit(u64),
+    /// The precise start position.
+    Explicit(u64),
+}
+
 /// Provides access to a decrypted age message.
 pub struct StreamReader<R: Read> {
     stream: Stream,
     inner: R,
-    start: u64,
+    start: StartPos,
     cur_plaintext_pos: u64,
     chunk: Option<SecretVec<u8>>,
+}
+
+impl<R: Read> StreamReader<R> {
+    fn count_bytes(&mut self, read: usize) {
+        // We only need to count if we haven't yet worked out the start position.
+        if let StartPos::Implicit(offset) = &mut self.start {
+            *offset += read as u64;
+        }
+    }
+}
+
+impl<R: Read + Seek> StreamReader<R> {
+    fn start(&mut self) -> io::Result<u64> {
+        match self.start {
+            StartPos::Implicit(offset) => {
+                let current = self.inner.seek(SeekFrom::Current(0))?;
+                let start = current - offset;
+
+                // Cache the start for future calls.
+                self.start = StartPos::Explicit(start);
+
+                Ok(start)
+            }
+            StartPos::Explicit(start) => Ok(start),
+        }
+    }
 }
 
 impl<R: Read> Read for StreamReader<R> {
@@ -221,6 +241,7 @@ impl<R: Read> Read for StreamReader<R> {
                     },
                 }
             }
+            self.count_bytes(end);
 
             if end == 0 {
                 if self.stream.nonce[11] == 0 {
@@ -269,6 +290,7 @@ impl<R: Read> Read for StreamReader<R> {
 impl<R: Read + Seek> Seek for StreamReader<R> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         // Convert the offset into the target position within the plaintext
+        let start = self.start()?;
         let target_pos = match pos {
             SeekFrom::Start(offset) => offset,
             SeekFrom::Current(offset) => {
@@ -289,7 +311,7 @@ impl<R: Read + Seek> Seek for StreamReader<R> {
 
                 let num_chunks = (ct_end / ENCRYPTED_CHUNK_SIZE as u64) + 1;
                 let total_tag_size = num_chunks * TAG_SIZE as u64;
-                let pt_end = ct_end - self.start - total_tag_size;
+                let pt_end = ct_end - start - total_tag_size;
 
                 let res = (pt_end as i64) + offset;
                 if res >= 0 {
@@ -317,7 +339,7 @@ impl<R: Read + Seek> Seek for StreamReader<R> {
 
             // Seek to the beginning of the target chunk
             self.inner.seek(SeekFrom::Start(
-                self.start + (target_chunk_index * ENCRYPTED_CHUNK_SIZE as u64),
+                start + (target_chunk_index * ENCRYPTED_CHUNK_SIZE as u64),
             ))?;
             self.stream.set_counter(target_chunk_index);
             self.cur_plaintext_pos = target_chunk_index * CHUNK_SIZE as u64;
@@ -519,7 +541,7 @@ mod tests {
             w.finish().unwrap();
         };
 
-        let mut r = Stream::decrypt_seekable(&key, Cursor::new(encrypted)).unwrap();
+        let mut r = Stream::decrypt(&key, Cursor::new(encrypted));
 
         // Read through into the second chunk
         let mut buf = vec![0; 100];

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -237,9 +237,7 @@ impl Decryptor {
                         })
                     })
                     .unwrap_or(Err(Error::NoMatchingKeys))
-                    .and_then(|payload_key| {
-                        Stream::decrypt_seekable(&payload_key, input).map_err(Error::from)
-                    })
+                    .map(|payload_key| Stream::decrypt(&payload_key, input))
             }
             Header::Unknown(_) => Err(Error::UnknownFormat),
         }

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -2,7 +2,7 @@
 
 use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, SecretString};
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read, Write};
 use std::iter;
 
 use crate::{
@@ -170,49 +170,9 @@ impl Decryptor {
     /// to be decrypted before it can be used to decrypt the message.
     ///
     /// If successful, returns a reader that will provide the plaintext.
-    pub fn trial_decrypt<R: Read>(&self, input: R) -> Result<impl Read, Error> {
+    pub fn trial_decrypt<R: Read>(&self, input: R) -> Result<StreamReader<R>, Error> {
         let mut input = ArmoredReader::from_reader(input);
 
-        match Header::read(&mut input)? {
-            Header::V1(header) => {
-                let mut nonce = [0; 16];
-                input.read_exact(&mut nonce)?;
-
-                header
-                    .recipients
-                    .iter()
-                    .find_map(|r| {
-                        self.unwrap_file_key(r).transpose().map(|res| {
-                            res.and_then(|file_key| {
-                                // Verify the MAC
-                                header.verify_mac(hkdf(
-                                    &[],
-                                    HEADER_KEY_LABEL,
-                                    file_key.0.expose_secret(),
-                                ))?;
-
-                                // Return the payload key
-                                Ok(hkdf(&nonce, PAYLOAD_KEY_LABEL, file_key.0.expose_secret()))
-                            })
-                        })
-                    })
-                    .unwrap_or(Err(Error::NoMatchingKeys))
-                    .map(|payload_key| Stream::decrypt(&payload_key, input))
-            }
-            Header::Unknown(_) => Err(Error::UnknownFormat),
-        }
-    }
-
-    /// Attempts to decrypt a message from the given seekable reader.
-    ///
-    /// `request_passphrase` is a closure that will be called when an underlying key needs
-    /// to be decrypted before it can be used to decrypt the message.
-    ///
-    /// If successful, returns a seekable reader that will provide the plaintext.
-    pub fn trial_decrypt_seekable<R: Read + Seek>(
-        &self,
-        mut input: R,
-    ) -> Result<StreamReader<R>, Error> {
         match Header::read(&mut input)? {
             Header::V1(header) => {
                 let mut nonce = [0; 16];

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Added
+- `rage-mount` can now mount ASCII-armored age files.
+
 ### Fixed
 - [Unix] Files encrypted with a passphrase can now be decrypted with `rage` when
   piped over stdin.

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -194,7 +194,7 @@ fn main() -> Result<(), Error> {
     info!("Decrypting {}", opts.filename);
     let file = File::open(opts.filename)?;
 
-    let stream = decryptor.trial_decrypt_seekable(file)?;
+    let stream = decryptor.trial_decrypt(file)?;
 
     match opts.types.as_str() {
         "tar" => mount_fs(|| crate::tar::AgeTarFs::open(stream), opts.mountpoint),


### PR DESCRIPTION
This along with some other refactors enables us to handle seekable and non-seekable readers with a single API.