### PR TITLE
Refactor age::Decryptor to auto-detect decryption type

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -9,13 +9,22 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Added
+- `age::Decryptor::new(R: Read)`, which parses an age file header and returns
+  a context-specific decryptor.
+- `age::decryptor` module containing the context-specific decryptors.
+  - Their decryption methods return the concrete type `StreamReader<R>`,
+    enabling them to handle seekable readers.
+
 ### Changed
-- `age::Decryptor::trial_decrypt` returns `StreamReader<R>` instead of
-  `impl Read`, enabling it to handle seekable readers.
+- `age::Decryptor` has been refactored to auto-detect the decryption type. As a
+  result, both identity-based and passphrase-based decryption need to be
+  handled.
 
 ### Removed
-- `age::Decryptor::trial_decrypt_seekable` (replaced by
-  `age::Decryptor::trial_decrypt`).
+- `age::Decryptor::trial_decrypt` (replaced by context-specific decryptors).
+- `age::Decryptor::trial_decrypt_seekable` (merged into the context-specific
+  decryptors).
 
 ### Fixed
 - Key files with Windows line endings are now correctly parsed.

--- a/age/src/error.rs
+++ b/age/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
         /// The target work factor for this device (around 1 second of work).
         target: u8,
     },
+    /// The age header was invalid.
+    InvalidHeader,
     /// The MAC in the message header was invalid.
     InvalidMac,
     /// An I/O error occurred during decryption.
@@ -46,6 +48,7 @@ impl fmt::Display for Error {
                     1 << (required - target)
                 )
             }
+            Error::InvalidHeader => write!(f, "Header is invalid"),
             Error::InvalidMac => write!(f, "Header MAC is invalid"),
             Error::Io(e) => e.fmt(f),
             Error::KeyDecryptionFailed => write!(f, "Failed to decrypt an encrypted key"),

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -34,10 +34,13 @@
 //!
 //! // ... and decrypt the obtained ciphertext to the plaintext again.
 //! let decrypted = {
-//!     let decryptor = age::Decryptor::with_identities(vec![key.into()]);
+//!     let decryptor = match age::Decryptor::new(&encrypted[..])? {
+//!         age::Decryptor::Recipients(d) => d,
+//!         _ => unreachable!(),
+//!     };
 //!
 //!     let mut decrypted = vec![];
-//!     let mut reader = decryptor.trial_decrypt(&encrypted[..])?;
+//!     let mut reader = decryptor.decrypt(&[key.into()])?;
 //!     reader.read_to_end(&mut decrypted);
 //!
 //!     decrypted
@@ -74,10 +77,13 @@
 //!
 //! // ... and decrypt the ciphertext to the plaintext again using the same passphrase.
 //! let decrypted = {
-//!     let decryptor = age::Decryptor::with_passphrase(Secret::new(passphrase.to_owned()));
+//!     let decryptor = match age::Decryptor::new(&encrypted[..])? {
+//!         age::Decryptor::Passphrase(d) => d,
+//!         _ => unreachable!(),
+//!     };
 //!
 //!     let mut decrypted = vec![];
-//!     let mut reader = decryptor.trial_decrypt(&encrypted[..])?;
+//!     let mut reader = decryptor.decrypt(&Secret::new(passphrase.to_owned()), None)?;
 //!     reader.read_to_end(&mut decrypted);
 //!
 //!     decrypted
@@ -112,7 +118,7 @@ mod util;
 pub use error::Error;
 pub use keys::SecretKey;
 pub use primitives::stream::StreamReader;
-pub use protocol::{Callbacks, Decryptor, Encryptor};
+pub use protocol::{decryptor, Callbacks, Decryptor, Encryptor};
 
 #[cfg(feature = "cli-common")]
 pub mod cli_common;

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -8,14 +8,16 @@ use std::iter;
 use crate::{
     error::Error,
     format::{oil_the_joint, scrypt, Header, HeaderV1, RecipientLine},
-    keys::{FileKey, Identity, RecipientKey},
+    keys::{FileKey, RecipientKey},
     primitives::{
         armor::{ArmoredReader, ArmoredWriter},
         hkdf,
-        stream::{Stream, StreamReader, StreamWriter},
+        stream::{Stream, StreamWriter},
     },
     Format,
 };
+
+pub mod decryptor;
 
 const HEADER_KEY_LABEL: &[u8] = b"header";
 const PAYLOAD_KEY_LABEL: &[u8] = b"payload";
@@ -97,109 +99,52 @@ impl Encryptor {
     }
 }
 
-/// Handles the various types of age decryption.
-pub enum Decryptor {
-    /// Trial decryption against a list of identities.
-    Identities {
-        /// The identities to use.
-        identities: Vec<Identity>,
-        /// A handler for any callbacks triggered by an `Identity`.
-        callbacks: Box<dyn Callbacks>,
-    },
+/// Decryptor for an age file.
+pub enum Decryptor<R: Read> {
+    /// Decryption with a list of identities.
+    Recipients(decryptor::RecipientsDecryptor<R>),
     /// Decryption with a passphrase.
-    Passphrase {
-        /// The passphrase to decrypt with.
-        passphrase: SecretString,
-        /// The maximum accepted work factor. If `None`, the default maximum is adjusted
-        /// to around 16 seconds of work.
-        max_work_factor: Option<u8>,
-    },
+    Passphrase(decryptor::PassphraseDecryptor<R>),
 }
 
-impl Decryptor {
-    /// Creates a decryptor with a list of identities.
-    ///
-    /// The decryptor will have no callbacks registered, so it will be unable to use
-    /// identities that require e.g. a passphrase to decrypt.
-    pub fn with_identities(identities: Vec<Identity>) -> Self {
-        Decryptor::Identities {
-            identities,
-            callbacks: Box::new(NoCallbacks),
-        }
+impl<R: Read> From<decryptor::RecipientsDecryptor<R>> for Decryptor<R> {
+    fn from(decryptor: decryptor::RecipientsDecryptor<R>) -> Self {
+        Decryptor::Recipients(decryptor)
     }
+}
 
-    /// Creates a decryptor with a list of identities and a callback handler.
-    ///
-    /// The decryptor will have no callbacks registered, so it will be unable to use
-    /// identities that require e.g. a passphrase to decrypt.
-    pub fn with_identities_and_callbacks(
-        identities: Vec<Identity>,
-        callbacks: Box<dyn Callbacks>,
-    ) -> Self {
-        Decryptor::Identities {
-            identities,
-            callbacks,
-        }
+impl<R: Read> From<decryptor::PassphraseDecryptor<R>> for Decryptor<R> {
+    fn from(decryptor: decryptor::PassphraseDecryptor<R>) -> Self {
+        Decryptor::Passphrase(decryptor)
     }
+}
 
-    /// Creates a decryptor with a passphrase and the default max work factor.
-    pub fn with_passphrase(passphrase: SecretString) -> Self {
-        Decryptor::Passphrase {
-            passphrase,
-            max_work_factor: None,
-        }
-    }
-
-    fn unwrap_file_key(&self, line: &RecipientLine) -> Result<Option<FileKey>, Error> {
-        match (self, line) {
-            (Decryptor::Identities { .. }, RecipientLine::Scrypt(_)) => {
-                Err(Error::MessageRequiresPassphrase)
-            }
-            (
-                Decryptor::Identities {
-                    identities,
-                    callbacks,
-                },
-                _,
-            ) => identities
-                .iter()
-                .find_map(|key| key.unwrap_file_key(line, callbacks.as_ref()))
-                .transpose(),
-            (
-                Decryptor::Passphrase {
-                    passphrase,
-                    max_work_factor,
-                },
-                RecipientLine::Scrypt(s),
-            ) => s.unwrap_file_key(passphrase, *max_work_factor),
-            (Decryptor::Passphrase { .. }, _) => Err(Error::MessageRequiresKeys),
-        }
-    }
-
-    /// Attempts to decrypt a message from the given reader.
+impl<R: Read> Decryptor<R> {
+    /// Attempts to create a decryptor for an age file.
     ///
-    /// `request_passphrase` is a closure that will be called when an underlying key needs
-    /// to be decrypted before it can be used to decrypt the message.
-    ///
-    /// If successful, returns a reader that will provide the plaintext.
-    pub fn trial_decrypt<R: Read>(&self, input: R) -> Result<StreamReader<R>, Error> {
+    /// Returns an error if the input does not contain a valid age file.
+    pub fn new(input: R) -> Result<Self, Error> {
         let mut input = ArmoredReader::from_reader(input);
+        let header = Header::read(&mut input)?;
 
-        match Header::read(&mut input)? {
-            Header::V1(header) => {
-                let mut nonce = [0; 16];
-                input.read_exact(&mut nonce)?;
+        match &header {
+            Header::V1(v1_header) => {
+                // Enforce structural requirements on the v1 header.
+                let any_scrypt = v1_header.recipients.iter().any(|r| {
+                    if let RecipientLine::Scrypt(_) = r {
+                        true
+                    } else {
+                        false
+                    }
+                });
 
-                header
-                    .recipients
-                    .iter()
-                    .find_map(|r| {
-                        self.unwrap_file_key(r).transpose().map(|res| {
-                            res.and_then(|file_key| v1_payload_key(&header, file_key, nonce))
-                        })
-                    })
-                    .unwrap_or(Err(Error::NoMatchingKeys))
-                    .map(|payload_key| Stream::decrypt(&payload_key, input))
+                if any_scrypt && v1_header.recipients.len() == 1 {
+                    Ok(decryptor::PassphraseDecryptor::new(input, header).into())
+                } else if !any_scrypt {
+                    Ok(decryptor::RecipientsDecryptor::new(input, header).into())
+                } else {
+                    Err(Error::InvalidHeader)
+                }
             }
             Header::Unknown(_) => Err(Error::UnknownFormat),
         }
@@ -231,8 +176,11 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::with_identities(sk);
-        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
+        let d = match Decryptor::new(&encrypted[..]) {
+            Ok(Decryptor::Recipients(d)) => d,
+            _ => panic!(),
+        };
+        let mut r = d.decrypt(&sk).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 
@@ -251,8 +199,13 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::with_passphrase(SecretString::new("passphrase".to_string()));
-        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
+        let d = match Decryptor::new(&encrypted[..]) {
+            Ok(Decryptor::Passphrase(d)) => d,
+            _ => panic!(),
+        };
+        let mut r = d
+            .decrypt(&SecretString::new("passphrase".to_string()), None)
+            .unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 
@@ -276,8 +229,11 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::with_identities(sk);
-        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
+        let d = match Decryptor::new(&encrypted[..]) {
+            Ok(Decryptor::Recipients(d)) => d,
+            _ => panic!(),
+        };
+        let mut r = d.decrypt(&sk).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 
@@ -300,8 +256,11 @@ mod tests {
             w.finish().unwrap();
         }
 
-        let d = Decryptor::with_identities(sk);
-        let mut r = d.trial_decrypt(&encrypted[..]).unwrap();
+        let d = match Decryptor::new(&encrypted[..]) {
+            Ok(Decryptor::Recipients(d)) => d,
+            _ => panic!(),
+        };
+        let mut r = d.decrypt(&sk).unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
 

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -1,0 +1,111 @@
+//! Decryptors for age.
+
+use secrecy::SecretString;
+use std::io::Read;
+
+use super::{v1_payload_key, Callbacks, NoCallbacks};
+use crate::{
+    error::Error,
+    format::{Header, RecipientLine},
+    keys::{FileKey, Identity},
+    primitives::{
+        armor::ArmoredReader,
+        stream::{Stream, StreamReader},
+    },
+};
+
+struct BaseDecryptor<R: Read> {
+    /// The age file.
+    input: ArmoredReader<R>,
+    /// The age file's header.
+    header: Header,
+}
+
+impl<R: Read> BaseDecryptor<R> {
+    fn obtain_payload_key<F>(&mut self, filter: F) -> Result<[u8; 32], Error>
+    where
+        F: FnMut(&RecipientLine) -> Option<Result<FileKey, Error>>,
+    {
+        match &self.header {
+            Header::V1(header) => {
+                let mut nonce = [0; 16];
+                self.input.read_exact(&mut nonce)?;
+
+                header
+                    .recipients
+                    .iter()
+                    .find_map(filter)
+                    .unwrap_or(Err(Error::NoMatchingKeys))
+                    .and_then(|file_key| v1_payload_key(header, file_key, nonce))
+            }
+            Header::Unknown(_) => unreachable!(),
+        }
+    }
+}
+
+/// Decryptor for an age file encrypted to a list of recipients.
+pub struct RecipientsDecryptor<R: Read>(BaseDecryptor<R>);
+
+impl<R: Read> RecipientsDecryptor<R> {
+    pub(super) fn new(input: ArmoredReader<R>, header: Header) -> Self {
+        RecipientsDecryptor(BaseDecryptor { input, header })
+    }
+
+    /// Attempts to decrypt the age file.
+    ///
+    /// The decryptor will have no callbacks registered, so it will be unable to use
+    /// identities that require e.g. a passphrase to decrypt.
+    ///
+    /// If successful, returns a reader that will provide the plaintext.
+    pub fn decrypt(self, identities: &[Identity]) -> Result<StreamReader<R>, Error> {
+        self.decrypt_with_callbacks(identities, &NoCallbacks)
+    }
+
+    /// Attempts to decrypt the age file.
+    ///
+    /// If successful, returns a reader that will provide the plaintext.
+    pub fn decrypt_with_callbacks(
+        mut self,
+        identities: &[Identity],
+        callbacks: &dyn Callbacks,
+    ) -> Result<StreamReader<R>, Error> {
+        self.0
+            .obtain_payload_key(|r| {
+                identities
+                    .iter()
+                    .find_map(|key| key.unwrap_file_key(r, callbacks))
+            })
+            .map(|payload_key| Stream::decrypt(&payload_key, self.0.input))
+    }
+}
+
+/// Decryptor for an age file encrypted with a passphrase.
+pub struct PassphraseDecryptor<R: Read>(BaseDecryptor<R>);
+
+impl<R: Read> PassphraseDecryptor<R> {
+    pub(super) fn new(input: ArmoredReader<R>, header: Header) -> Self {
+        PassphraseDecryptor(BaseDecryptor { input, header })
+    }
+
+    /// Attempts to decrypt the age file.
+    ///
+    /// `max_work_factor` is the maximum accepted work factor. If `None`, the default
+    /// maximum is adjusted to around 16 seconds of work.
+    ///
+    /// If successful, returns a reader that will provide the plaintext.
+    pub fn decrypt(
+        mut self,
+        passphrase: &SecretString,
+        max_work_factor: Option<u8>,
+    ) -> Result<StreamReader<R>, Error> {
+        self.0
+            .obtain_payload_key(|r| {
+                if let RecipientLine::Scrypt(s) = r {
+                    s.unwrap_file_key(passphrase, max_work_factor).transpose()
+                } else {
+                    None
+                }
+            })
+            .map(|payload_key| Stream::decrypt(&payload_key, self.0.input))
+    }
+}

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -12,6 +12,14 @@ to 1.0.0 are beta releases.
 ### Added
 - `rage-mount` can now mount ASCII-armored age files.
 
+### Changed
+- [`rage`] `-p/--passphrase` flag can no longer be used with `-d/--decrypt`
+  (passphrase-encrypted files are now detected automatically).
+
+### Removed
+- `-p/--passphrase` flag from `rage-mount` (passphrase-encrypted files are now
+  detected automatically).
+
 ### Fixed
 - [Unix] Files encrypted with a passphrase can now be decrypted with `rage` when
   piped over stdin.

--- a/rage/examples/generate-completions.rs
+++ b/rage/examples/generate-completions.rs
@@ -80,7 +80,6 @@ fn rage_mount_completions() {
         .arg(Arg::with_name("filename"))
         .arg(Arg::with_name("mountpoint"))
         .arg(Arg::with_name("types").short('t').long("types"))
-        .arg(Arg::with_name("passphrase").short('p').long("passphrase"))
         .arg(
             Arg::with_name("max-work-factor")
                 .takes_value(true)

--- a/rage/examples/generate-docs.rs
+++ b/rage/examples/generate-docs.rs
@@ -197,12 +197,6 @@ fn rage_mount_page() {
                 .long("--types")
                 .help("The type of the filesystem (one of \"tar\", \"zip\")"),
         )
-        .flag(
-            Flag::new()
-                .short("-p")
-                .long("--passphrase")
-                .help("Use a passphrase instead of public keys"),
-        )
         .option(
             Opt::new("identity")
                 .short("-i")
@@ -224,7 +218,7 @@ fn rage_mount_page() {
         .example(
             Example::new()
                 .text("Mounting an archive encrypted with a passphrase")
-                .command("rage-mount -t zip -p encrypted.zip.age ./tmp")
+                .command("rage-mount -t zip encrypted.zip.age ./tmp")
                 .output("Type passphrase:"),
         )
         .render();

--- a/rage/examples/generate-docs.rs
+++ b/rage/examples/generate-docs.rs
@@ -213,7 +213,7 @@ fn rage_mount_page() {
         .example(
             Example::new()
                 .text("Mounting an archive with custom keys")
-                .command("rage-mount -t tar encrypted.tar.age ./tmp key.txt"),
+                .command("rage-mount -t tar -i key.txt encrypted.tar.age ./tmp"),
         )
         .example(
             Example::new()

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -57,7 +57,7 @@ pub(crate) enum DecryptError {
     ArmorFlag,
     Io(io::Error),
     MissingIdentities(String),
-    MixedIdentityAndPassphrase,
+    PassphraseFlag,
     #[cfg(not(unix))]
     PassphraseWithoutFileArgument,
     RecipientFlag,
@@ -98,14 +98,19 @@ impl fmt::Display for DecryptError {
                 writeln!(f, "You can also store default identities in this file:")?;
                 write!(f, "    {}", default_filename)
             }
-            DecryptError::MixedIdentityAndPassphrase => {
-                write!(f, "-i/--identity can't be used with -p/--passphrase")
+            DecryptError::PassphraseFlag => {
+                writeln!(f, "-p/--passphrase can't be used with -d/--decrypt.")?;
+                write!(
+                    f,
+                    "Note that passphrase-encrypted files are detected automatically."
+                )
             }
             #[cfg(not(unix))]
-            DecryptError::PassphraseWithoutFileArgument => write!(
-                f,
-                "File to decrypt must be passed as an argument when using -p/--passphrase on Windows"
-            ),
+            DecryptError::PassphraseWithoutFileArgument => {
+                writeln!(f, "This file requires a passphrase, and on Windows the")?;
+                writeln!(f, "file to decrypt must be passed as a positional argument")?;
+                write!(f, "when decrypting with a passphrase.")
+            }
             DecryptError::RecipientFlag => {
                 writeln!(f, "-r/--recipient can't be used with -d/--decrypt.")?;
                 write!(


### PR DESCRIPTION
The decryption workflow has been inverted: the file header is parsed to detect the decryption type, and this is then represented as an enum of concrete decryptors with context-specific `decrypt()` methods.

The `-p/--passphrase` flag has been removed from rage-mount, and is now not required for decryption with rage.

Closes #83.