### PR TITLE
age_core: Expose primitives for AEAD and HKDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,8 +98,12 @@ name = "age-core"
 version = "0.4.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chacha20poly1305 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie-factory 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Added
+- `age_core::primitives::{aead_decrypt, aead_encrypt, hkdf}`, to enable these
+  common primitives to be reused in plugins.
 
 ## [0.4.0] - 2020-03-25
 No changes; version bumped to keep it in sync with `age`.

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -12,6 +12,18 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
+# Dependencies required by the age specification:
+# - Base64 from RFC 4648
 base64 = "0.11"
+
+# - ChaCha20-Poly1305 from RFC 7539
+c2-chacha = "0.2"
+chacha20poly1305 = { version = "0.4", default-features = false, features = ["alloc"] }
+
+# - HKDF from RFC 5869 with SHA-256
+hkdf = "0.8"
+sha2 = "0.8"
+
+# Parsing
 cookie-factory = "0.3.1"
 nom = "5"

--- a/age-core/src/lib.rs
+++ b/age-core/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod format;
+pub mod primitives;

--- a/age-core/src/primitives.rs
+++ b/age-core/src/primitives.rs
@@ -1,0 +1,56 @@
+//! Primitive cryptographic operations used across various `age` components.
+
+use chacha20poly1305::{
+    aead::{self, Aead, NewAead},
+    ChaChaPoly1305,
+};
+use hkdf::Hkdf;
+use sha2::Sha256;
+
+/// `encrypt[key](plaintext)`
+///
+/// ChaCha20-Poly1305 from [RFC 7539] with a zero nonce.
+///
+/// [RFC 7539]: https://tools.ietf.org/html/rfc7539
+pub fn aead_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
+    let c = ChaChaPoly1305::<c2_chacha::Ietf>::new((*key).into());
+    c.encrypt(&[0; 12].into(), plaintext)
+        .expect("we won't overflow the ChaCha20 block counter")
+}
+
+/// `decrypt[key](ciphertext)`
+///
+/// ChaCha20-Poly1305 from [RFC 7539] with a zero nonce.
+///
+/// [RFC 7539]: https://tools.ietf.org/html/rfc7539
+pub fn aead_decrypt(key: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, aead::Error> {
+    let c = ChaChaPoly1305::<c2_chacha::Ietf>::new((*key).into());
+    c.decrypt(&[0; 12].into(), ciphertext)
+}
+
+/// `HKDF[salt, label](key, 32)`
+///
+/// HKDF from [RFC 5869] with SHA-256.
+///
+/// [RFC 5869]: https://tools.ietf.org/html/rfc5869
+pub fn hkdf(salt: &[u8], label: &[u8], ikm: &[u8]) -> [u8; 32] {
+    let mut okm = [0; 32];
+    Hkdf::<Sha256>::new(Some(salt), ikm)
+        .expand(label, &mut okm)
+        .expect("okm is the correct length");
+    okm
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{aead_decrypt, aead_encrypt};
+
+    #[test]
+    fn aead_round_trip() {
+        let key = [14; 32];
+        let plaintext = b"12345678";
+        let encrypted = aead_encrypt(&key, plaintext);
+        let decrypted = aead_decrypt(&key, &encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+}

--- a/age/src/format/scrypt.rs
+++ b/age/src/format/scrypt.rs
@@ -1,15 +1,13 @@
-use age_core::format::AgeStanza;
+use age_core::{
+    format::AgeStanza,
+    primitives::{aead_decrypt, aead_encrypt},
+};
 use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::convert::TryInto;
 use std::time::Duration;
 
-use crate::{
-    error::Error,
-    keys::FileKey,
-    primitives::{aead_decrypt, aead_encrypt, scrypt},
-    util::read::base64_arg,
-};
+use crate::{error::Error, keys::FileKey, primitives::scrypt, util::read::base64_arg};
 
 pub(super) const SCRYPT_RECIPIENT_TAG: &str = "scrypt";
 const SCRYPT_SALT_LABEL: &[u8] = b"age-encryption.org/v1/scrypt";

--- a/age/src/format/ssh_ed25519.rs
+++ b/age/src/format/ssh_ed25519.rs
@@ -1,4 +1,7 @@
-use age_core::format::AgeStanza;
+use age_core::{
+    format::AgeStanza,
+    primitives::{aead_decrypt, aead_encrypt, hkdf},
+};
 use curve25519_dalek::edwards::EdwardsPoint;
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, Secret};
@@ -7,11 +10,7 @@ use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
 use crate::{
-    error::Error,
-    format::x25519::ENCRYPTED_FILE_KEY_BYTES,
-    keys::FileKey,
-    primitives::{aead_decrypt, aead_encrypt, hkdf},
-    util::read::base64_arg,
+    error::Error, format::x25519::ENCRYPTED_FILE_KEY_BYTES, keys::FileKey, util::read::base64_arg,
 };
 
 pub(super) const SSH_ED25519_RECIPIENT_TAG: &str = "ssh-ed25519";

--- a/age/src/format/x25519.rs
+++ b/age/src/format/x25519.rs
@@ -1,15 +1,13 @@
-use age_core::format::AgeStanza;
+use age_core::{
+    format::AgeStanza,
+    primitives::{aead_decrypt, aead_encrypt, hkdf},
+};
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, Secret};
 use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
-use crate::{
-    error::Error,
-    keys::FileKey,
-    primitives::{aead_decrypt, aead_encrypt, hkdf},
-    util::read::base64_arg,
-};
+use crate::{error::Error, keys::FileKey, util::read::base64_arg};
 
 pub(super) const X25519_RECIPIENT_TAG: &str = "X25519";
 const X25519_RECIPIENT_KEY_LABEL: &[u8] = b"age-encryption.org/v1/X25519";

--- a/age/src/primitives.rs
+++ b/age/src/primitives.rs
@@ -1,10 +1,5 @@
 //! Primitive cryptographic operations used by `age`.
 
-use chacha20poly1305::{
-    aead::{self, Aead, NewAead},
-    ChaChaPoly1305,
-};
-use hkdf::Hkdf;
 use hmac::{
     crypto_mac::{generic_array::typenum::U32, MacError, MacResult},
     Hmac, Mac,
@@ -15,40 +10,6 @@ use std::io::{self, Write};
 
 pub(crate) mod armor;
 pub mod stream;
-
-/// `encrypt[key](plaintext)`
-///
-/// ChaCha20-Poly1305 from [RFC 7539] with a zero nonce.
-///
-/// [RFC 7539]: https://tools.ietf.org/html/rfc7539
-pub(crate) fn aead_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
-    let c = ChaChaPoly1305::<c2_chacha::Ietf>::new((*key).into());
-    c.encrypt(&[0; 12].into(), plaintext)
-        .expect("we won't overflow the ChaCha20 block counter")
-}
-
-/// `decrypt[key](ciphertext)`
-///
-/// ChaCha20-Poly1305 from [RFC 7539] with a zero nonce.
-///
-/// [RFC 7539]: https://tools.ietf.org/html/rfc7539
-pub(crate) fn aead_decrypt(key: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, aead::Error> {
-    let c = ChaChaPoly1305::<c2_chacha::Ietf>::new((*key).into());
-    c.decrypt(&[0; 12].into(), ciphertext)
-}
-
-/// `HKDF[salt, label](key, 32)`
-///
-/// HKDF from [RFC 5869] with SHA-256.
-///
-/// [RFC 5869]: https://tools.ietf.org/html/rfc5869
-pub(crate) fn hkdf(salt: &[u8], label: &[u8], ikm: &[u8]) -> [u8; 32] {
-    let mut okm = [0; 32];
-    Hkdf::<Sha256>::new(Some(salt), ikm)
-        .expand(label, &mut okm)
-        .expect("okm is the correct length");
-    okm
-}
 
 /// `HMAC[key](message)`
 ///
@@ -101,18 +62,4 @@ pub(crate) fn scrypt(salt: &[u8], log_n: u8, password: &str) -> Result<[u8; 32],
     scrypt_inner(password.as_bytes(), salt, &params, &mut output)
         .expect("output is the correct length");
     Ok(output)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{aead_decrypt, aead_encrypt};
-
-    #[test]
-    fn aead_round_trip() {
-        let key = [14; 32];
-        let plaintext = b"12345678";
-        let encrypted = aead_encrypt(&key, plaintext);
-        let decrypted = aead_decrypt(&key, &encrypted).unwrap();
-        assert_eq!(decrypted, plaintext);
-    }
 }

--- a/age/src/primitives/stream.rs
+++ b/age/src/primitives/stream.rs
@@ -39,7 +39,7 @@ impl Stream {
     /// achieved by deriving the key with [`HKDF`] from both a random file key and a
     /// random nonce.
     ///
-    /// [`HKDF`]: crate::primitives::hkdf
+    /// [`HKDF`]: age_core::primitives::hkdf
     pub(crate) fn encrypt<W: Write>(key: &[u8; 32], inner: ArmoredWriter<W>) -> StreamWriter<W> {
         StreamWriter {
             stream: Self::new(key),
@@ -54,7 +54,7 @@ impl Stream {
     /// achieved by deriving the key with [`HKDF`] from both a random file key and a
     /// random nonce.
     ///
-    /// [`HKDF`]: crate::primitives::hkdf
+    /// [`HKDF`]: age_core::primitives::hkdf
     pub(crate) fn decrypt<R: Read>(key: &[u8; 32], inner: ArmoredReader<R>) -> StreamReader<R> {
         StreamReader {
             stream: Self::new(key),

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -1,5 +1,6 @@
 //! Encryption and decryption routines for age.
 
+use age_core::primitives::hkdf;
 use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, SecretString};
 use std::io::{self, Read, Write};
@@ -11,7 +12,6 @@ use crate::{
     keys::{FileKey, RecipientKey},
     primitives::{
         armor::{ArmoredReader, ArmoredWriter},
-        hkdf,
         stream::{Stream, StreamWriter},
     },
     Format,


### PR DESCRIPTION
This enables reuse of these common primitives within the upcoming plugin
system, alongside the core parsers and serializers.