### PR TITLE
Introduce an Identity trait

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -23,6 +23,9 @@ to 1.0.0 are beta releases.
   optionally apply the armored age format.
 
 ### Changed
+- `age::decryptor::RecipientsDecryptor` now takes
+  `impl Iterator<Item = Identity>` in its decryption methods instead of
+  `&[Identity]`.
 - `age::Encryptor::wrap_output` now only generates the non-malleable binary age
   format. Use `encryptor.wrap_output(ArmoredWriter::wrap_output(output, format))`
   to optionally generate armored age files.

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -19,7 +19,6 @@ to 1.0.0 are beta releases.
   - `age::Encryptor::wrap_async_output()`
   - `age::Decryptor::new_async()`
   - `age::decryptor::RecipientsDecryptor::decrypt_async()`
-  - `age::decryptor::RecipientsDecryptor::decrypt_async_with_callbacks()`
   - `age::decryptor::PassphraseDecryptor::decrypt_async()`
 - `age::armor::ArmoredReader`, which can be wrapped around an input to handle
   a potentially-armored age file.
@@ -45,6 +44,8 @@ to 1.0.0 are beta releases.
 ### Removed
 - `age::keys::{Identity, IdentityKey}` (replaced by `age::Identity` trait on
   individual identities, and `age::IdentityFile` for parsing identities).
+- `age::decryptor::RecipientsDecryptor::decrypt_with_callbacks()` (identities
+  are now expected to handle their own callbacks).
 
 ## [0.4.0] - 2020-03-25
 ### Added

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -12,6 +12,8 @@ to 1.0.0 are beta releases.
 ### Added
 - `age::Identity` trait, representing an identity that can decrypt an age file.
   All relevant `age` types implement this trait.
+- `age::IdentityFile` struct, for parsing a list of native age identities from a
+  file.
 - Asynchronous APIs for encryption and decryption, enabled by the `async`
   feature flag:
   - `age::Encryptor::wrap_async_output()`
@@ -37,6 +39,12 @@ to 1.0.0 are beta releases.
 - `age::Format` has been moved to `age::armor::Format`.
 - SSH support has been moved into the `age::ssh` module.
 - OpenSSH `ssh-rsa` keys are now supported without the `unstable` feature flag.
+- `age::cli_common::read_identities` now returns `Vec<Box<dyn Identity>>`, as it
+  abstracts over `age::IdentityFile` and `age::ssh::Identity`.
+
+### Removed
+- `age::keys::{Identity, IdentityKey}` (replaced by `age::Identity` trait on
+  individual identities, and `age::IdentityFile` for parsing identities).
 
 ## [0.4.0] - 2020-03-25
 ### Added

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -10,6 +10,8 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 ### Added
+- `age::Identity` trait, representing an identity that can decrypt an age file.
+  All relevant `age` types implement this trait.
 - Asynchronous APIs for encryption and decryption, enabled by the `async`
   feature flag:
   - `age::Encryptor::wrap_async_output()`
@@ -21,11 +23,11 @@ to 1.0.0 are beta releases.
   a potentially-armored age file.
 - `age::armor::ArmoredWriter`, which can be wrapped around an output to
   optionally apply the armored age format.
+- `age::keys::FileKey` (used when implementing the `age::Identity` trait).
 
 ### Changed
 - `age::decryptor::RecipientsDecryptor` now takes
-  `impl Iterator<Item = Identity>` in its decryption methods instead of
-  `&[Identity]`.
+  `impl Iterator<Item = Box<dyn Identity>>` in its decryption methods.
 - `age::Encryptor::wrap_output` now only generates the non-malleable binary age
   format. Use `encryptor.wrap_output(ArmoredWriter::wrap_output(output, format))`
   to optionally generate armored age files.

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -76,7 +76,7 @@ where
                 Ok(crate::ssh::Identity::Unsupported(k)) => {
                     return Err(unsupported_ssh(filename, k))
                 }
-                Ok(identity) => identities.push(Box::new(identity)),
+                Ok(identity) => identities.push(Box::new(identity.with_callbacks(UiCallbacks))),
                 Err(_) => {
                     // Try parsing as multiple single-line age identities.
                     identities.push(Box::new(

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -23,7 +23,7 @@ const RECIPIENT_TAG: &[u8] = b"-> ";
 const MAC_TAG: &[u8] = b"---";
 
 #[derive(Debug)]
-pub(crate) enum RecipientStanza {
+pub enum RecipientStanza {
     X25519(x25519::RecipientStanza),
     Scrypt(scrypt::RecipientStanza),
     SshRsa(ssh_rsa::RecipientStanza),

--- a/age/src/format/plugin.rs
+++ b/age/src/format/plugin.rs
@@ -1,7 +1,7 @@
 use age_core::format::AgeStanza;
 
 #[derive(Debug)]
-pub(crate) struct RecipientStanza {
+pub struct RecipientStanza {
     pub(crate) tag: String,
     pub(crate) args: Vec<String>,
     pub(crate) body: Vec<u8>,

--- a/age/src/format/scrypt.rs
+++ b/age/src/format/scrypt.rs
@@ -56,7 +56,7 @@ fn target_scrypt_work_factor() -> u8 {
 }
 
 #[derive(Debug)]
-pub(crate) struct RecipientStanza {
+pub struct RecipientStanza {
     pub(crate) salt: [u8; SALT_LEN],
     pub(crate) log_n: u8,
     pub(crate) encrypted_file_key: [u8; ENCRYPTED_FILE_KEY_BYTES],

--- a/age/src/format/ssh_ed25519.rs
+++ b/age/src/format/ssh_ed25519.rs
@@ -26,7 +26,7 @@ fn ssh_tag(pubkey: &[u8]) -> [u8; TAG_LEN_BYTES] {
 }
 
 #[derive(Debug)]
-pub(crate) struct RecipientStanza {
+pub struct RecipientStanza {
     pub(crate) tag: [u8; TAG_LEN_BYTES],
     pub(crate) rest: super::x25519::RecipientStanza,
 }

--- a/age/src/format/ssh_rsa.rs
+++ b/age/src/format/ssh_rsa.rs
@@ -1,8 +1,10 @@
 use age_core::format::AgeStanza;
 use rand::rngs::OsRng;
 use rsa::{padding::PaddingScheme, PublicKey, RSAPrivateKey, RSAPublicKey};
-use secrecy::{ExposeSecret, Secret};
+use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
+use std::convert::TryInto;
+use zeroize::Zeroize;
 
 use crate::{error::Error, keys::FileKey, util::read::base64_arg};
 
@@ -45,7 +47,7 @@ impl RecipientStanza {
             .encrypt(
                 &mut rng,
                 PaddingScheme::new_oaep_with_label::<Sha256, _>(SSH_RSA_OAEP_LABEL),
-                file_key.0.expose_secret(),
+                file_key.expose_secret(),
             )
             .expect("pubkey is valid and file key is not too long");
 
@@ -75,11 +77,11 @@ impl RecipientStanza {
                 &self.encrypted_file_key,
             )
             .map_err(Error::from)
-            .map(|pt| {
+            .map(|mut pt| {
                 // It's ours!
-                let mut file_key = [0; 16];
-                file_key.copy_from_slice(&pt);
-                FileKey(Secret::new(file_key))
+                let file_key: [u8; 16] = pt[..].try_into().unwrap();
+                pt.zeroize();
+                file_key.into()
             }),
         )
     }

--- a/age/src/format/ssh_rsa.rs
+++ b/age/src/format/ssh_rsa.rs
@@ -19,7 +19,7 @@ fn ssh_tag(pubkey: &[u8]) -> [u8; TAG_LEN_BYTES] {
 }
 
 #[derive(Debug)]
-pub(crate) struct RecipientStanza {
+pub struct RecipientStanza {
     pub(crate) tag: [u8; TAG_LEN_BYTES],
     pub(crate) encrypted_file_key: Vec<u8>,
 }

--- a/age/src/format/x25519.rs
+++ b/age/src/format/x25519.rs
@@ -16,7 +16,7 @@ pub(super) const EPK_LEN_BYTES: usize = 32;
 pub(super) const ENCRYPTED_FILE_KEY_BYTES: usize = 32;
 
 #[derive(Debug)]
-pub(crate) struct RecipientStanza {
+pub struct RecipientStanza {
     pub(crate) epk: PublicKey,
     pub(crate) encrypted_file_key: [u8; ENCRYPTED_FILE_KEY_BYTES],
 }

--- a/age/src/format/x25519.rs
+++ b/age/src/format/x25519.rs
@@ -3,9 +3,10 @@ use age_core::{
     primitives::{aead_decrypt, aead_encrypt, hkdf},
 };
 use rand::rngs::OsRng;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::ExposeSecret;
 use std::convert::TryInto;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
+use zeroize::Zeroize;
 
 use crate::{error::Error, keys::FileKey, util::read::base64_arg};
 
@@ -48,7 +49,7 @@ impl RecipientStanza {
         let enc_key = hkdf(&salt, X25519_RECIPIENT_KEY_LABEL, shared_secret.as_bytes());
         let encrypted_file_key = {
             let mut key = [0; ENCRYPTED_FILE_KEY_BYTES];
-            key.copy_from_slice(&aead_encrypt(&enc_key, file_key.0.expose_secret()));
+            key.copy_from_slice(&aead_encrypt(&enc_key, file_key.expose_secret()));
             key
         };
 
@@ -70,11 +71,11 @@ impl RecipientStanza {
 
         aead_decrypt(&enc_key, &self.encrypted_file_key)
             .map_err(Error::from)
-            .map(|pt| {
+            .map(|mut pt| {
                 // It's ours!
-                let mut file_key = [0; 16];
-                file_key.copy_from_slice(&pt);
-                FileKey(Secret::new(file_key))
+                let file_key: [u8; 16] = pt[..].try_into().unwrap();
+                pt.zeroize();
+                file_key.into()
             })
     }
 }
@@ -102,11 +103,10 @@ pub(super) mod write {
 mod tests {
     use quickcheck::TestResult;
     use quickcheck_macros::quickcheck;
-    use secrecy::{ExposeSecret, Secret};
+    use secrecy::ExposeSecret;
     use x25519_dalek::{PublicKey, StaticSecret};
 
     use super::RecipientStanza;
-    use crate::keys::FileKey;
 
     #[quickcheck]
     fn wrap_and_unwrap(sk_bytes: Vec<u8>) -> TestResult {
@@ -114,7 +114,7 @@ mod tests {
             return TestResult::discard();
         }
 
-        let file_key = FileKey(Secret::new([7; 16]));
+        let file_key = [7; 16].into();
         let sk = {
             let mut tmp = [0; 32];
             tmp[..sk_bytes.len()].copy_from_slice(&sk_bytes);
@@ -125,7 +125,7 @@ mod tests {
         let res = stanza.unwrap_file_key(&sk);
 
         TestResult::from_bool(
-            res.is_ok() && res.unwrap().0.expose_secret() == file_key.0.expose_secret(),
+            res.is_ok() && res.unwrap().expose_secret() == file_key.expose_secret(),
         )
     }
 }

--- a/age/src/identity.rs
+++ b/age/src/identity.rs
@@ -5,7 +5,6 @@ use crate::{
     error::Error,
     format::RecipientStanza,
     keys::{FileKey, SecretKey},
-    protocol::Callbacks,
     Identity,
 };
 
@@ -62,11 +61,7 @@ impl IdentityFile {
 }
 
 impl Identity for IdentityFile {
-    fn unwrap_file_key(
-        &self,
-        stanza: &RecipientStanza,
-        _callbacks: &dyn Callbacks,
-    ) -> Option<Result<FileKey, Error>> {
+    fn unwrap_file_key(&self, stanza: &RecipientStanza) -> Option<Result<FileKey, Error>> {
         self.identities
             .iter()
             .find_map(|identity| identity.unwrap_file_key(stanza))

--- a/age/src/identity.rs
+++ b/age/src/identity.rs
@@ -1,0 +1,191 @@
+use std::fs::File;
+use std::io;
+
+use crate::{
+    error::Error,
+    format::RecipientStanza,
+    keys::{FileKey, SecretKey},
+    protocol::Callbacks,
+    Identity,
+};
+
+/// A list of identities that has been parsed from some input file.
+pub struct IdentityFile {
+    /// The name of the identity file, if known.
+    filename: Option<String>,
+    identities: Vec<SecretKey>,
+}
+
+impl IdentityFile {
+    /// Parses one or more identities from a file containing valid UTF-8.
+    pub fn from_file(filename: String) -> io::Result<Self> {
+        let buf = io::BufReader::new(File::open(filename.clone())?);
+        let mut keys = IdentityFile::from_buffer(buf)?;
+
+        // We have context here about the filename.
+        keys.filename = Some(filename.clone());
+
+        Ok(keys)
+    }
+
+    /// Parses one or more identities from a buffered input containing valid UTF-8.
+    pub fn from_buffer<R: io::BufRead>(mut data: R) -> io::Result<Self> {
+        let mut buf = String::new();
+        loop {
+            match read::age_secret_keys(&buf) {
+                Ok((_, identities)) => {
+                    // Ensure we've found all identities in the file
+                    if data.read_line(&mut buf)? == 0 {
+                        break Ok(IdentityFile {
+                            filename: None,
+                            identities,
+                        });
+                    }
+                }
+                Err(nom::Err::Incomplete(nom::Needed::Size(_))) => {
+                    if data.read_line(&mut buf)? == 0 {
+                        break Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "incomplete secret keys in file",
+                        ));
+                    };
+                }
+                Err(_) => {
+                    break Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid secret key file",
+                    ));
+                }
+            }
+        }
+    }
+}
+
+impl Identity for IdentityFile {
+    fn unwrap_file_key(
+        &self,
+        stanza: &RecipientStanza,
+        _callbacks: &dyn Callbacks,
+    ) -> Option<Result<FileKey, Error>> {
+        self.identities
+            .iter()
+            .find_map(|identity| identity.unwrap_file_key(stanza))
+    }
+}
+
+mod read {
+    use nom::{
+        branch::alt,
+        bytes::streaming::tag,
+        character::complete::{line_ending, not_line_ending},
+        combinator::{all_consuming, iterator, map, map_parser, rest},
+        sequence::{terminated, tuple},
+        IResult,
+    };
+
+    use crate::keys::{read::age_secret_key, SecretKey};
+
+    fn age_secret_keys_line(input: &str) -> IResult<&str, Option<SecretKey>> {
+        alt((
+            // Skip empty lines
+            map(all_consuming(tag("")), |_| None),
+            // Skip comments
+            map(all_consuming(tuple((tag("#"), rest))), |_| None),
+            // All other lines must be valid age secret keys.
+            map(all_consuming(age_secret_key), Some),
+        ))(input)
+    }
+
+    pub(super) fn age_secret_keys(input: &str) -> IResult<&str, Vec<SecretKey>> {
+        // Parse all lines that have line endings.
+        let mut it = iterator(
+            input,
+            terminated(
+                map_parser(not_line_ending, age_secret_keys_line),
+                line_ending,
+            ),
+        );
+        let mut keys: Vec<_> = it.filter_map(|x| x).collect();
+
+        it.finish().and_then(|(i, _)| {
+            // Handle the last line, which does not have a line ending.
+            age_secret_keys_line(i).map(|(i, res)| {
+                if let Some(k) = res {
+                    keys.push(k);
+                }
+                (i, keys)
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use secrecy::ExposeSecret;
+    use std::io::BufReader;
+
+    use super::IdentityFile;
+
+    pub(crate) const TEST_SK: &str =
+        "AGE-SECRET-KEY-1GQ9778VQXMMJVE8SK7J6VT8UJ4HDQAJUVSFCWCM02D8GEWQ72PVQ2Y5J33";
+
+    fn valid_secret_key_encoding(keydata: &str, num_keys: usize) {
+        let buf = BufReader::new(keydata.as_bytes());
+        let f = IdentityFile::from_buffer(buf).unwrap();
+        assert_eq!(f.identities.len(), num_keys);
+        assert_eq!(f.identities[0].to_string().expose_secret(), TEST_SK);
+    }
+
+    #[test]
+    fn secret_key_encoding() {
+        valid_secret_key_encoding(TEST_SK, 1);
+    }
+
+    #[test]
+    fn secret_key_lf() {
+        valid_secret_key_encoding(&format!("{}\n", TEST_SK), 1);
+    }
+
+    #[test]
+    fn two_secret_keys_lf() {
+        valid_secret_key_encoding(&format!("{}\n{}", TEST_SK, TEST_SK), 2);
+    }
+
+    #[test]
+    fn secret_key_with_comment_lf() {
+        valid_secret_key_encoding(&format!("# Foo bar baz\n{}", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("{}\n# Foo bar baz", TEST_SK), 1);
+    }
+
+    #[test]
+    fn secret_key_with_empty_line_lf() {
+        valid_secret_key_encoding(&format!("\n\n{}", TEST_SK), 1);
+    }
+
+    #[test]
+    fn secret_key_crlf() {
+        valid_secret_key_encoding(&format!("{}\r\n", TEST_SK), 1);
+    }
+
+    #[test]
+    fn two_secret_keys_crlf() {
+        valid_secret_key_encoding(&format!("{}\r\n{}", TEST_SK, TEST_SK), 2);
+    }
+
+    #[test]
+    fn secret_key_with_comment_crlf() {
+        valid_secret_key_encoding(&format!("# Foo bar baz\r\n{}", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("{}\r\n# Foo bar baz", TEST_SK), 1);
+    }
+
+    #[test]
+    fn secret_key_with_empty_line_crlf() {
+        valid_secret_key_encoding(&format!("\r\n\r\n{}", TEST_SK), 1);
+    }
+
+    #[test]
+    fn incomplete_secret_key_encoding() {
+        let buf = BufReader::new(&TEST_SK.as_bytes()[..4]);
+        assert!(IdentityFile::from_buffer(buf).is_err());
+    }
+}

--- a/age/src/keys.rs
+++ b/age/src/keys.rs
@@ -13,7 +13,7 @@ use crate::{
     error::Error,
     format::{x25519, HeaderV1, RecipientStanza},
     primitives::{stream::PayloadKey, HmacKey},
-    protocol::{Callbacks, Nonce},
+    protocol::Nonce,
     ssh,
 };
 
@@ -101,15 +101,10 @@ impl SecretKey {
     pub fn to_public(&self) -> RecipientKey {
         RecipientKey::X25519((&self.0).into())
     }
+}
 
-    /// Returns:
-    /// - `Some(Ok(file_key))` on success.
-    /// - `Some(Err(e))` if a decryption error occurs.
-    /// - `None` if the [`RecipientStanza`] does not match this key.
-    pub(crate) fn unwrap_file_key(
-        &self,
-        stanza: &RecipientStanza,
-    ) -> Option<Result<FileKey, Error>> {
+impl crate::Identity for SecretKey {
+    fn unwrap_file_key(&self, stanza: &RecipientStanza) -> Option<Result<FileKey, Error>> {
         match stanza {
             RecipientStanza::X25519(r) => {
                 // A failure to decrypt is non-fatal (we try to decrypt the recipient
@@ -119,16 +114,6 @@ impl SecretKey {
             }
             _ => None,
         }
-    }
-}
-
-impl crate::Identity for SecretKey {
-    fn unwrap_file_key(
-        &self,
-        stanza: &RecipientStanza,
-        _callbacks: &dyn Callbacks,
-    ) -> Option<Result<FileKey, Error>> {
-        self.unwrap_file_key(stanza)
     }
 }
 

--- a/age/src/keys.rs
+++ b/age/src/keys.rs
@@ -6,8 +6,6 @@ use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::convert::TryInto;
 use std::fmt;
-use std::fs::File;
-use std::io::{self, BufRead, BufReader};
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::Zeroize;
 
@@ -134,110 +132,6 @@ impl crate::Identity for SecretKey {
     }
 }
 
-/// An key that has been parsed from some input.
-pub enum IdentityKey {
-    /// An X25519 age key.
-    X25519(SecretKey),
-    /// An SSH private key.
-    Ssh(ssh::Identity),
-}
-
-/// An identity that has been parsed from some input.
-pub struct Identity {
-    filename: Option<String>,
-    key: IdentityKey,
-}
-
-impl From<SecretKey> for Identity {
-    fn from(key: SecretKey) -> Self {
-        Identity {
-            filename: None,
-            key: IdentityKey::X25519(key),
-        }
-    }
-}
-
-impl From<ssh::Identity> for Identity {
-    fn from(key: ssh::Identity) -> Self {
-        Identity {
-            filename: None,
-            key: IdentityKey::Ssh(key),
-        }
-    }
-}
-
-impl Identity {
-    /// Parses one or more identities from a file containing valid UTF-8.
-    pub fn from_file(filename: String) -> io::Result<Vec<Self>> {
-        let buf = BufReader::new(File::open(filename.clone())?);
-        let mut keys = Identity::from_buffer(buf)?;
-
-        // We have context here about the filename.
-        for key in &mut keys {
-            key.filename = Some(filename.clone());
-        }
-
-        Ok(keys)
-    }
-
-    /// Parses one or more identities from a buffered input containing valid UTF-8.
-    pub fn from_buffer<R: BufRead>(mut data: R) -> io::Result<Vec<Self>> {
-        let mut buf = String::new();
-        loop {
-            match read::age_secret_keys(&buf) {
-                Ok((_, keys)) => {
-                    // Ensure we've found all keys in the file
-                    if data.read_line(&mut buf)? == 0 {
-                        break Ok(keys);
-                    }
-                }
-                Err(nom::Err::Incomplete(nom::Needed::Size(_))) => {
-                    if data.read_line(&mut buf)? == 0 {
-                        break Err(io::Error::new(
-                            io::ErrorKind::Interrupted,
-                            "incomplete secret keys in file",
-                        ));
-                    };
-                }
-                Err(_) => {
-                    break Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "invalid secret key file",
-                    ));
-                }
-            }
-        }
-    }
-
-    /// Returns the key corresponding to this identity.
-    pub fn key(&self) -> &IdentityKey {
-        &self.key
-    }
-
-    pub(crate) fn unwrap_file_key(
-        &self,
-        stanza: &RecipientStanza,
-        callbacks: &dyn Callbacks,
-    ) -> Option<Result<FileKey, Error>> {
-        use crate::Identity;
-
-        match &self.key {
-            IdentityKey::X25519(key) => key.unwrap_file_key(stanza),
-            IdentityKey::Ssh(key) => key.unwrap_file_key(stanza, callbacks),
-        }
-    }
-}
-
-impl crate::Identity for Identity {
-    fn unwrap_file_key(
-        &self,
-        stanza: &RecipientStanza,
-        callbacks: &dyn Callbacks,
-    ) -> Option<Result<FileKey, Error>> {
-        self.unwrap_file_key(stanza, callbacks)
-    }
-}
-
 /// A key that can be used to encrypt a file to a recipient.
 #[derive(Clone, Debug)]
 pub enum RecipientKey {
@@ -307,138 +201,31 @@ impl RecipientKey {
     }
 }
 
-mod read {
+pub(crate) mod read {
     use nom::{
-        branch::alt,
-        bytes::streaming::{tag, take},
-        character::complete::{line_ending, not_line_ending},
-        combinator::{all_consuming, iterator, map, map_opt, map_parser, map_res, rest},
-        sequence::{terminated, tuple},
+        bytes::streaming::take,
+        combinator::{map_opt, map_res},
         IResult,
     };
 
     use super::*;
 
-    fn age_secret_key(input: &str) -> IResult<&str, Identity> {
+    pub(crate) fn age_secret_key(input: &str) -> IResult<&str, SecretKey> {
         map_res(
             map_opt(take(74u32), |buf| parse_bech32(buf, SECRET_KEY_PREFIX)),
-            |pk| {
-                pk.map(StaticSecret::from)
-                    .map(SecretKey)
-                    .map(Identity::from)
-            },
+            |pk| pk.map(StaticSecret::from).map(SecretKey),
         )(input)
-    }
-
-    fn age_secret_keys_line(input: &str) -> IResult<&str, Option<Identity>> {
-        alt((
-            // Skip empty lines
-            map(all_consuming(tag("")), |_| None),
-            // Skip comments
-            map(all_consuming(tuple((tag("#"), rest))), |_| None),
-            // All other lines must be valid age secret keys.
-            map(all_consuming(age_secret_key), Some),
-        ))(input)
-    }
-
-    pub(super) fn age_secret_keys(input: &str) -> IResult<&str, Vec<Identity>> {
-        // Parse all lines that have line endings.
-        let mut it = iterator(
-            input,
-            terminated(
-                map_parser(not_line_ending, age_secret_keys_line),
-                line_ending,
-            ),
-        );
-        let mut keys: Vec<_> = it.filter_map(|x| x).collect();
-
-        it.finish().and_then(|(i, _)| {
-            // Handle the last line, which does not have a line ending.
-            age_secret_keys_line(i).map(|(i, res)| {
-                if let Some(k) = res {
-                    keys.push(k);
-                }
-                (i, keys)
-            })
-        })
     }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use secrecy::ExposeSecret;
-    use std::io::BufReader;
-
-    use super::{Identity, IdentityKey, RecipientKey};
+    use super::{read::age_secret_key, RecipientKey};
 
     pub(crate) const TEST_SK: &str =
         "AGE-SECRET-KEY-1GQ9778VQXMMJVE8SK7J6VT8UJ4HDQAJUVSFCWCM02D8GEWQ72PVQ2Y5J33";
     pub(crate) const TEST_PK: &str =
         "age1t7rxyev2z3rw82stdlrrepyc39nvn86l5078zqkf5uasdy86jp6svpy7pa";
-
-    fn valid_secret_key_encoding(keydata: &str, num_keys: usize) {
-        let buf = BufReader::new(keydata.as_bytes());
-        let keys = Identity::from_buffer(buf).unwrap();
-        assert_eq!(keys.len(), num_keys);
-        let key = match keys[0].key() {
-            IdentityKey::X25519(key) => key,
-            _ => panic!("key should be X25519"),
-        };
-        assert_eq!(key.to_string().expose_secret(), TEST_SK);
-    }
-
-    #[test]
-    fn secret_key_encoding() {
-        valid_secret_key_encoding(TEST_SK, 1);
-    }
-
-    #[test]
-    fn secret_key_lf() {
-        valid_secret_key_encoding(&format!("{}\n", TEST_SK), 1);
-    }
-
-    #[test]
-    fn two_secret_keys_lf() {
-        valid_secret_key_encoding(&format!("{}\n{}", TEST_SK, TEST_SK), 2);
-    }
-
-    #[test]
-    fn secret_key_with_comment_lf() {
-        valid_secret_key_encoding(&format!("# Foo bar baz\n{}", TEST_SK), 1);
-        valid_secret_key_encoding(&format!("{}\n# Foo bar baz", TEST_SK), 1);
-    }
-
-    #[test]
-    fn secret_key_with_empty_line_lf() {
-        valid_secret_key_encoding(&format!("\n\n{}", TEST_SK), 1);
-    }
-
-    #[test]
-    fn secret_key_crlf() {
-        valid_secret_key_encoding(&format!("{}\r\n", TEST_SK), 1);
-    }
-
-    #[test]
-    fn two_secret_keys_crlf() {
-        valid_secret_key_encoding(&format!("{}\r\n{}", TEST_SK, TEST_SK), 2);
-    }
-
-    #[test]
-    fn secret_key_with_comment_crlf() {
-        valid_secret_key_encoding(&format!("# Foo bar baz\r\n{}", TEST_SK), 1);
-        valid_secret_key_encoding(&format!("{}\r\n# Foo bar baz", TEST_SK), 1);
-    }
-
-    #[test]
-    fn secret_key_with_empty_line_crlf() {
-        valid_secret_key_encoding(&format!("\r\n\r\n{}", TEST_SK), 1);
-    }
-
-    #[test]
-    fn incomplete_secret_key_encoding() {
-        let buf = BufReader::new(&TEST_SK.as_bytes()[..4]);
-        assert!(Identity::from_buffer(buf).is_err());
-    }
 
     #[test]
     fn pubkey_encoding() {
@@ -448,13 +235,7 @@ pub(crate) mod tests {
 
     #[test]
     fn pubkey_from_secret_key() {
-        let buf = BufReader::new(TEST_SK.as_bytes());
-        let keys = Identity::from_buffer(buf).unwrap();
-        assert_eq!(keys.len(), 1);
-        let key = match keys[0].key() {
-            IdentityKey::X25519(key) => key,
-            _ => panic!("key should be unencrypted"),
-        };
+        let (_, key) = age_secret_key(TEST_SK).unwrap();
         assert_eq!(key.to_public().to_string(), TEST_PK);
     }
 }

--- a/age/src/keys.rs
+++ b/age/src/keys.rs
@@ -39,13 +39,25 @@ fn parse_bech32(s: &str, expected_hrp: &str) -> Option<Result<[u8; 32], &'static
 }
 
 /// A file key for encrypting or decrypting an age file.
-pub struct FileKey(pub(crate) Secret<[u8; 16]>);
+pub struct FileKey(Secret<[u8; 16]>);
+
+impl From<[u8; 16]> for FileKey {
+    fn from(file_key: [u8; 16]) -> Self {
+        FileKey(Secret::new(file_key))
+    }
+}
+
+impl ExposeSecret<[u8; 16]> for FileKey {
+    fn expose_secret(&self) -> &[u8; 16] {
+        self.0.expose_secret()
+    }
+}
 
 impl FileKey {
     pub(crate) fn generate() -> Self {
         let mut file_key = [0; 16];
         OsRng.fill_bytes(&mut file_key);
-        FileKey(Secret::new(file_key))
+        file_key.into()
     }
 
     pub(crate) fn mac_key(&self) -> HmacKey {

--- a/age/src/keys.rs
+++ b/age/src/keys.rs
@@ -40,7 +40,8 @@ fn parse_bech32(s: &str, expected_hrp: &str) -> Option<Result<[u8; 32], &'static
     })
 }
 
-pub(crate) struct FileKey(pub(crate) Secret<[u8; 16]>);
+/// A file key for encrypting or decrypting an age file.
+pub struct FileKey(pub(crate) Secret<[u8; 16]>);
 
 impl FileKey {
     pub(crate) fn generate() -> Self {
@@ -120,6 +121,16 @@ impl SecretKey {
             }
             _ => None,
         }
+    }
+}
+
+impl crate::Identity for SecretKey {
+    fn unwrap_file_key(
+        &self,
+        stanza: &RecipientStanza,
+        _callbacks: &dyn Callbacks,
+    ) -> Option<Result<FileKey, Error>> {
+        self.unwrap_file_key(stanza)
     }
 }
 
@@ -208,10 +219,22 @@ impl Identity {
         stanza: &RecipientStanza,
         callbacks: &dyn Callbacks,
     ) -> Option<Result<FileKey, Error>> {
+        use crate::Identity;
+
         match &self.key {
             IdentityKey::X25519(key) => key.unwrap_file_key(stanza),
             IdentityKey::Ssh(key) => key.unwrap_file_key(stanza, callbacks),
         }
+    }
+}
+
+impl crate::Identity for Identity {
+    fn unwrap_file_key(
+        &self,
+        stanza: &RecipientStanza,
+        callbacks: &dyn Callbacks,
+    ) -> Option<Result<FileKey, Error>> {
+        self.unwrap_file_key(stanza, callbacks)
     }
 }
 

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -141,7 +141,6 @@ pub trait Identity {
     fn unwrap_file_key(
         &self,
         stanza: &format::RecipientStanza,
-        callbacks: &dyn Callbacks,
     ) -> Option<Result<keys::FileKey, Error>>;
 }
 

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -104,6 +104,7 @@
 
 mod error;
 mod format;
+mod identity;
 pub mod keys;
 mod primitives;
 mod protocol;
@@ -111,6 +112,7 @@ pub mod ssh;
 mod util;
 
 pub use error::Error;
+pub use identity::IdentityFile;
 pub use keys::SecretKey;
 pub use primitives::{armor, stream};
 pub use protocol::{decryptor, Callbacks, Decryptor, Encryptor};

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! ```
 //! use std::io::{Read, Write};
+//! use std::iter;
 //!
 //! # fn run_main() -> Result<(), age::Error> {
 //! let key = age::SecretKey::generate();
@@ -40,7 +41,7 @@
 //!     };
 //!
 //!     let mut decrypted = vec![];
-//!     let mut reader = decryptor.decrypt(&[key.into()])?;
+//!     let mut reader = decryptor.decrypt(iter::once(key.into()))?;
 //!     reader.read_to_end(&mut decrypted);
 //!
 //!     decrypted

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -230,7 +230,7 @@ mod tests {
     use std::iter;
 
     use super::{Decryptor, Encryptor};
-    use crate::keys::{Identity, RecipientKey};
+    use crate::{identity::IdentityFile, keys::RecipientKey, Identity};
 
     #[cfg(feature = "async")]
     use futures::{
@@ -244,7 +244,7 @@ mod tests {
 
     fn recipient_round_trip(
         recipients: Vec<RecipientKey>,
-        identities: impl Iterator<Item = Box<dyn crate::Identity>>,
+        identities: impl Iterator<Item = Box<dyn Identity>>,
     ) {
         let test_msg = b"This is a test message. For testing.";
 
@@ -270,7 +270,7 @@ mod tests {
     #[cfg(feature = "async")]
     fn recipient_async_round_trip(
         recipients: Vec<RecipientKey>,
-        identities: impl Iterator<Item = Box<dyn crate::Identity>>,
+        identities: impl Iterator<Item = Box<dyn Identity>>,
     ) {
         let test_msg = b"This is a test message. For testing.";
         let mut cx = noop_context();
@@ -348,26 +348,18 @@ mod tests {
     #[test]
     fn x25519_round_trip() {
         let buf = BufReader::new(crate::keys::tests::TEST_SK.as_bytes());
-        let sk = Identity::from_buffer(buf).unwrap();
+        let sk = IdentityFile::from_buffer(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_PK.parse().unwrap();
-        recipient_round_trip(
-            vec![pk],
-            sk.into_iter()
-                .map(|i| Box::new(i) as Box<dyn crate::Identity>),
-        );
+        recipient_round_trip(vec![pk], iter::once(Box::new(sk) as Box<dyn Identity>));
     }
 
     #[cfg(feature = "async")]
     #[test]
     fn x25519_async_round_trip() {
         let buf = BufReader::new(crate::keys::tests::TEST_SK.as_bytes());
-        let sk = Identity::from_buffer(buf).unwrap();
+        let sk = IdentityFile::from_buffer(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_PK.parse().unwrap();
-        recipient_async_round_trip(
-            vec![pk],
-            sk.into_iter()
-                .map(|i| Box::new(i) as Box<dyn crate::Identity>),
-        );
+        recipient_async_round_trip(vec![pk], iter::once(Box::new(sk) as Box<dyn Identity>));
     }
 
     #[test]
@@ -402,10 +394,7 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_RSA_PK
             .parse()
             .unwrap();
-        recipient_round_trip(
-            vec![pk],
-            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
-        );
+        recipient_round_trip(vec![pk], iter::once(Box::new(sk) as Box<dyn Identity>));
     }
 
     #[cfg(feature = "async")]
@@ -416,10 +405,7 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_RSA_PK
             .parse()
             .unwrap();
-        recipient_async_round_trip(
-            vec![pk],
-            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
-        );
+        recipient_async_round_trip(vec![pk], iter::once(Box::new(sk) as Box<dyn Identity>));
     }
 
     #[test]
@@ -429,10 +415,7 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_ED25519_PK
             .parse()
             .unwrap();
-        recipient_round_trip(
-            vec![pk],
-            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
-        );
+        recipient_round_trip(vec![pk], iter::once(Box::new(sk) as Box<dyn Identity>));
     }
 
     #[cfg(feature = "async")]
@@ -443,9 +426,6 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_ED25519_PK
             .parse()
             .unwrap();
-        recipient_async_round_trip(
-            vec![pk],
-            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
-        );
+        recipient_async_round_trip(vec![pk], iter::once(Box::new(sk) as Box<dyn Identity>));
     }
 }

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -244,7 +244,7 @@ mod tests {
 
     fn recipient_round_trip(
         recipients: Vec<RecipientKey>,
-        identities: impl Iterator<Item = Identity>,
+        identities: impl Iterator<Item = Box<dyn crate::Identity>>,
     ) {
         let test_msg = b"This is a test message. For testing.";
 
@@ -270,7 +270,7 @@ mod tests {
     #[cfg(feature = "async")]
     fn recipient_async_round_trip(
         recipients: Vec<RecipientKey>,
-        identities: impl Iterator<Item = Identity>,
+        identities: impl Iterator<Item = Box<dyn crate::Identity>>,
     ) {
         let test_msg = b"This is a test message. For testing.";
         let mut cx = noop_context();
@@ -350,7 +350,11 @@ mod tests {
         let buf = BufReader::new(crate::keys::tests::TEST_SK.as_bytes());
         let sk = Identity::from_buffer(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_PK.parse().unwrap();
-        recipient_round_trip(vec![pk], sk.into_iter());
+        recipient_round_trip(
+            vec![pk],
+            sk.into_iter()
+                .map(|i| Box::new(i) as Box<dyn crate::Identity>),
+        );
     }
 
     #[cfg(feature = "async")]
@@ -359,7 +363,11 @@ mod tests {
         let buf = BufReader::new(crate::keys::tests::TEST_SK.as_bytes());
         let sk = Identity::from_buffer(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_PK.parse().unwrap();
-        recipient_async_round_trip(vec![pk], sk.into_iter());
+        recipient_async_round_trip(
+            vec![pk],
+            sk.into_iter()
+                .map(|i| Box::new(i) as Box<dyn crate::Identity>),
+        );
     }
 
     #[test]
@@ -394,7 +402,10 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_RSA_PK
             .parse()
             .unwrap();
-        recipient_round_trip(vec![pk], iter::once(sk.into()));
+        recipient_round_trip(
+            vec![pk],
+            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
+        );
     }
 
     #[cfg(feature = "async")]
@@ -405,7 +416,10 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_RSA_PK
             .parse()
             .unwrap();
-        recipient_async_round_trip(vec![pk], iter::once(sk.into()));
+        recipient_async_round_trip(
+            vec![pk],
+            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
+        );
     }
 
     #[test]
@@ -415,7 +429,10 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_ED25519_PK
             .parse()
             .unwrap();
-        recipient_round_trip(vec![pk], iter::once(sk.into()));
+        recipient_round_trip(
+            vec![pk],
+            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
+        );
     }
 
     #[cfg(feature = "async")]
@@ -426,6 +443,9 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_ED25519_PK
             .parse()
             .unwrap();
-        recipient_async_round_trip(vec![pk], iter::once(sk.into()));
+        recipient_async_round_trip(
+            vec![pk],
+            iter::once(Box::new(sk) as Box<dyn crate::Identity>),
+        );
     }
 }

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -52,14 +52,6 @@ pub trait Callbacks {
     fn request_passphrase(&self, description: &str) -> Option<SecretString>;
 }
 
-struct NoCallbacks;
-
-impl Callbacks for NoCallbacks {
-    fn request_passphrase(&self, _description: &str) -> Option<SecretString> {
-        None
-    }
-}
-
 /// Handles the various types of age encryption.
 enum EncryptorType {
     /// Encryption to a list of recipients identified by keys.

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -227,6 +227,7 @@ impl<R: AsyncRead + Unpin> Decryptor<R> {
 mod tests {
     use secrecy::SecretString;
     use std::io::{BufReader, Read, Write};
+    use std::iter;
 
     use super::{Decryptor, Encryptor};
     use crate::keys::{Identity, RecipientKey};
@@ -241,7 +242,10 @@ mod tests {
     #[cfg(feature = "async")]
     use futures_test::task::noop_context;
 
-    fn recipient_round_trip(recipients: Vec<RecipientKey>, identities: &[Identity]) {
+    fn recipient_round_trip(
+        recipients: Vec<RecipientKey>,
+        identities: impl Iterator<Item = Identity>,
+    ) {
         let test_msg = b"This is a test message. For testing.";
 
         let mut encrypted = vec![];
@@ -264,7 +268,10 @@ mod tests {
     }
 
     #[cfg(feature = "async")]
-    fn recipient_async_round_trip(recipients: Vec<RecipientKey>, identities: &[Identity]) {
+    fn recipient_async_round_trip(
+        recipients: Vec<RecipientKey>,
+        identities: impl Iterator<Item = Identity>,
+    ) {
         let test_msg = b"This is a test message. For testing.";
         let mut cx = noop_context();
 
@@ -343,7 +350,7 @@ mod tests {
         let buf = BufReader::new(crate::keys::tests::TEST_SK.as_bytes());
         let sk = Identity::from_buffer(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_PK.parse().unwrap();
-        recipient_round_trip(vec![pk], &sk);
+        recipient_round_trip(vec![pk], sk.into_iter());
     }
 
     #[cfg(feature = "async")]
@@ -352,7 +359,7 @@ mod tests {
         let buf = BufReader::new(crate::keys::tests::TEST_SK.as_bytes());
         let sk = Identity::from_buffer(buf).unwrap();
         let pk: RecipientKey = crate::keys::tests::TEST_PK.parse().unwrap();
-        recipient_async_round_trip(vec![pk], &sk);
+        recipient_async_round_trip(vec![pk], sk.into_iter());
     }
 
     #[test]
@@ -387,7 +394,7 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_RSA_PK
             .parse()
             .unwrap();
-        recipient_round_trip(vec![pk], &[sk.into()]);
+        recipient_round_trip(vec![pk], iter::once(sk.into()));
     }
 
     #[cfg(feature = "async")]
@@ -398,7 +405,7 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_RSA_PK
             .parse()
             .unwrap();
-        recipient_async_round_trip(vec![pk], &[sk.into()]);
+        recipient_async_round_trip(vec![pk], iter::once(sk.into()));
     }
 
     #[test]
@@ -408,7 +415,7 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_ED25519_PK
             .parse()
             .unwrap();
-        recipient_round_trip(vec![pk], &[sk.into()]);
+        recipient_round_trip(vec![pk], iter::once(sk.into()));
     }
 
     #[cfg(feature = "async")]
@@ -419,6 +426,6 @@ mod tests {
         let pk: RecipientKey = crate::ssh::recipient::tests::TEST_SSH_ED25519_PK
             .parse()
             .unwrap();
-        recipient_async_round_trip(vec![pk], &[sk.into()]);
+        recipient_async_round_trip(vec![pk], iter::once(sk.into()));
     }
 }

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -3,7 +3,7 @@
 use secrecy::SecretString;
 use std::io::Read;
 
-use super::{Callbacks, NoCallbacks, Nonce};
+use super::Nonce;
 use crate::{
     error::Error,
     format::{Header, RecipientStanza},
@@ -56,36 +56,21 @@ impl<R> RecipientsDecryptor<R> {
     fn obtain_payload_key(
         &self,
         mut identities: impl Iterator<Item = Box<dyn Identity>>,
-        callbacks: &dyn Callbacks,
     ) -> Result<PayloadKey, Error> {
         self.0
-            .obtain_payload_key(|r| identities.find_map(|key| key.unwrap_file_key(r, callbacks)))
+            .obtain_payload_key(|r| identities.find_map(|key| key.unwrap_file_key(r)))
     }
 }
 
 impl<R: Read> RecipientsDecryptor<R> {
     /// Attempts to decrypt the age file.
     ///
-    /// The decryptor will have no callbacks registered, so it will be unable to use
-    /// identities that require e.g. a passphrase to decrypt.
-    ///
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt(
         self,
         identities: impl Iterator<Item = Box<dyn Identity>>,
     ) -> Result<StreamReader<R>, Error> {
-        self.decrypt_with_callbacks(identities, &NoCallbacks)
-    }
-
-    /// Attempts to decrypt the age file.
-    ///
-    /// If successful, returns a reader that will provide the plaintext.
-    pub fn decrypt_with_callbacks(
-        self,
-        identities: impl Iterator<Item = Box<dyn Identity>>,
-        callbacks: &dyn Callbacks,
-    ) -> Result<StreamReader<R>, Error> {
-        self.obtain_payload_key(identities, callbacks)
+        self.obtain_payload_key(identities)
             .map(|payload_key| Stream::decrypt(payload_key, self.0.input))
     }
 }
@@ -94,26 +79,12 @@ impl<R: Read> RecipientsDecryptor<R> {
 impl<R: AsyncRead + Unpin> RecipientsDecryptor<R> {
     /// Attempts to decrypt the age file.
     ///
-    /// The decryptor will have no callbacks registered, so it will be unable to use
-    /// identities that require e.g. a passphrase to decrypt.
-    ///
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt_async(
         self,
         identities: impl Iterator<Item = Box<dyn Identity>>,
     ) -> Result<StreamReader<R>, Error> {
-        self.decrypt_async_with_callbacks(identities, &NoCallbacks)
-    }
-
-    /// Attempts to decrypt the age file.
-    ///
-    /// If successful, returns a reader that will provide the plaintext.
-    pub fn decrypt_async_with_callbacks(
-        self,
-        identities: impl Iterator<Item = Box<dyn Identity>>,
-        callbacks: &dyn Callbacks,
-    ) -> Result<StreamReader<R>, Error> {
-        self.obtain_payload_key(identities, callbacks)
+        self.obtain_payload_key(identities)
             .map(|payload_key| Stream::decrypt_async(payload_key, self.0.input))
     }
 }

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -7,8 +7,9 @@ use super::{Callbacks, NoCallbacks, Nonce};
 use crate::{
     error::Error,
     format::{Header, RecipientStanza},
-    keys::{FileKey, Identity},
+    keys::FileKey,
     primitives::stream::{PayloadKey, Stream, StreamReader},
+    Identity,
 };
 
 #[cfg(feature = "async")]
@@ -54,7 +55,7 @@ impl<R> RecipientsDecryptor<R> {
 
     fn obtain_payload_key(
         &self,
-        mut identities: impl Iterator<Item = Identity>,
+        mut identities: impl Iterator<Item = Box<dyn Identity>>,
         callbacks: &dyn Callbacks,
     ) -> Result<PayloadKey, Error> {
         self.0
@@ -71,7 +72,7 @@ impl<R: Read> RecipientsDecryptor<R> {
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt(
         self,
-        identities: impl Iterator<Item = Identity>,
+        identities: impl Iterator<Item = Box<dyn Identity>>,
     ) -> Result<StreamReader<R>, Error> {
         self.decrypt_with_callbacks(identities, &NoCallbacks)
     }
@@ -81,7 +82,7 @@ impl<R: Read> RecipientsDecryptor<R> {
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt_with_callbacks(
         self,
-        identities: impl Iterator<Item = Identity>,
+        identities: impl Iterator<Item = Box<dyn Identity>>,
         callbacks: &dyn Callbacks,
     ) -> Result<StreamReader<R>, Error> {
         self.obtain_payload_key(identities, callbacks)
@@ -99,7 +100,7 @@ impl<R: AsyncRead + Unpin> RecipientsDecryptor<R> {
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt_async(
         self,
-        identities: impl Iterator<Item = Identity>,
+        identities: impl Iterator<Item = Box<dyn Identity>>,
     ) -> Result<StreamReader<R>, Error> {
         self.decrypt_async_with_callbacks(identities, &NoCallbacks)
     }
@@ -109,7 +110,7 @@ impl<R: AsyncRead + Unpin> RecipientsDecryptor<R> {
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt_async_with_callbacks(
         self,
-        identities: impl Iterator<Item = Identity>,
+        identities: impl Iterator<Item = Box<dyn Identity>>,
         callbacks: &dyn Callbacks,
     ) -> Result<StreamReader<R>, Error> {
         self.obtain_payload_key(identities, callbacks)

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -54,14 +54,11 @@ impl<R> RecipientsDecryptor<R> {
 
     fn obtain_payload_key(
         &self,
-        identities: &[Identity],
+        mut identities: impl Iterator<Item = Identity>,
         callbacks: &dyn Callbacks,
     ) -> Result<PayloadKey, Error> {
-        self.0.obtain_payload_key(|r| {
-            identities
-                .iter()
-                .find_map(|key| key.unwrap_file_key(r, callbacks))
-        })
+        self.0
+            .obtain_payload_key(|r| identities.find_map(|key| key.unwrap_file_key(r, callbacks)))
     }
 }
 
@@ -72,7 +69,10 @@ impl<R: Read> RecipientsDecryptor<R> {
     /// identities that require e.g. a passphrase to decrypt.
     ///
     /// If successful, returns a reader that will provide the plaintext.
-    pub fn decrypt(self, identities: &[Identity]) -> Result<StreamReader<R>, Error> {
+    pub fn decrypt(
+        self,
+        identities: impl Iterator<Item = Identity>,
+    ) -> Result<StreamReader<R>, Error> {
         self.decrypt_with_callbacks(identities, &NoCallbacks)
     }
 
@@ -81,7 +81,7 @@ impl<R: Read> RecipientsDecryptor<R> {
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt_with_callbacks(
         self,
-        identities: &[Identity],
+        identities: impl Iterator<Item = Identity>,
         callbacks: &dyn Callbacks,
     ) -> Result<StreamReader<R>, Error> {
         self.obtain_payload_key(identities, callbacks)
@@ -97,7 +97,10 @@ impl<R: AsyncRead + Unpin> RecipientsDecryptor<R> {
     /// identities that require e.g. a passphrase to decrypt.
     ///
     /// If successful, returns a reader that will provide the plaintext.
-    pub fn decrypt_async(self, identities: &[Identity]) -> Result<StreamReader<R>, Error> {
+    pub fn decrypt_async(
+        self,
+        identities: impl Iterator<Item = Identity>,
+    ) -> Result<StreamReader<R>, Error> {
         self.decrypt_async_with_callbacks(identities, &NoCallbacks)
     }
 
@@ -106,7 +109,7 @@ impl<R: AsyncRead + Unpin> RecipientsDecryptor<R> {
     /// If successful, returns a reader that will provide the plaintext.
     pub fn decrypt_async_with_callbacks(
         self,
-        identities: &[Identity],
+        identities: impl Iterator<Item = Identity>,
         callbacks: &dyn Callbacks,
     ) -> Result<StreamReader<R>, Error> {
         self.obtain_payload_key(identities, callbacks)

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -281,16 +281,13 @@ pub(crate) fn ssh_identity(input: &str) -> IResult<&str, Identity> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use secrecy::{ExposeSecret, Secret};
+    use secrecy::ExposeSecret;
     use std::io::BufReader;
 
     use super::Identity;
-    use crate::{
-        keys::FileKey,
-        ssh::recipient::{
-            tests::{TEST_SSH_ED25519_PK, TEST_SSH_RSA_PK},
-            Recipient,
-        },
+    use crate::ssh::recipient::{
+        tests::{TEST_SSH_ED25519_PK, TEST_SSH_RSA_PK},
+        Recipient,
     };
 
     pub(crate) const TEST_SSH_RSA_SK: &str = "-----BEGIN RSA PRIVATE KEY-----
@@ -339,13 +336,13 @@ AAAEADBJvjZT8X6JRJI8xVq/1aU8nMVgOtVnmdwqWwrSlXG3sKLqeplhpW+uObz5dvMgjz
         };
         let pk: Recipient = TEST_SSH_RSA_PK.parse().unwrap();
 
-        let file_key = FileKey(Secret::new([12; 16]));
+        let file_key = [12; 16].into();
 
         let wrapped = pk.wrap_file_key(&file_key);
         let unwrapped = sk.unwrap_file_key(&wrapped);
         assert_eq!(
-            unwrapped.unwrap().unwrap().0.expose_secret(),
-            file_key.0.expose_secret()
+            unwrapped.unwrap().unwrap().expose_secret(),
+            file_key.expose_secret()
         );
     }
 
@@ -359,13 +356,13 @@ AAAEADBJvjZT8X6JRJI8xVq/1aU8nMVgOtVnmdwqWwrSlXG3sKLqeplhpW+uObz5dvMgjz
         };
         let pk: Recipient = TEST_SSH_ED25519_PK.parse().unwrap();
 
-        let file_key = FileKey(Secret::new([12; 16]));
+        let file_key = [12; 16].into();
 
         let wrapped = pk.wrap_file_key(&file_key);
         let unwrapped = sk.unwrap_file_key(&wrapped);
         assert_eq!(
-            unwrapped.unwrap().unwrap().0.expose_secret(),
-            file_key.0.expose_secret()
+            unwrapped.unwrap().unwrap().expose_secret(),
+            file_key.expose_secret()
         );
     }
 }

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -178,8 +178,10 @@ impl Identity {
             }
         }
     }
+}
 
-    pub(crate) fn unwrap_file_key(
+impl crate::Identity for Identity {
+    fn unwrap_file_key(
         &self,
         stanza: &RecipientStanza,
         callbacks: &dyn Callbacks,

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -199,7 +199,12 @@ fn main() -> Result<(), Error> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
+                .decrypt_with_callbacks(
+                    identities
+                        .into_iter()
+                        .map(|i| Box::new(i) as Box<dyn age::Identity>),
+                    &UiCallbacks,
+                )
                 .map_err(|e| e.into())
                 .and_then(|stream| mount_stream(stream, types, mountpoint))
         }

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -199,12 +199,7 @@ fn main() -> Result<(), Error> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(
-                    identities
-                        .into_iter()
-                        .map(|i| Box::new(i) as Box<dyn age::Identity>),
-                    &UiCallbacks,
-                )
+                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
                 .map_err(|e| e.into())
                 .and_then(|stream| mount_stream(stream, types, mountpoint))
         }

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -2,7 +2,7 @@
 
 use age::{
     armor::ArmoredReader,
-    cli_common::{read_identities, read_secret, UiCallbacks},
+    cli_common::{read_identities, read_secret},
     stream::StreamReader,
 };
 use fuse_mt::FilesystemMT;
@@ -199,7 +199,7 @@ fn main() -> Result<(), Error> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
+                .decrypt(identities.into_iter())
                 .map_err(|e| e.into())
                 .and_then(|stream| mount_stream(stream, types, mountpoint))
         }

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -199,7 +199,7 @@ fn main() -> Result<(), Error> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(&identities, &UiCallbacks)
+                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
                 .map_err(|e| e.into())
                 .and_then(|stream| mount_stream(stream, types, mountpoint))
         }

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -4,7 +4,7 @@ use age::{
     armor::{ArmoredReader, ArmoredWriter, Format},
     cli_common::{
         file_io, get_config_dir, read_identities, read_or_generate_passphrase, read_secret,
-        Passphrase, UiCallbacks,
+        Passphrase,
     },
 };
 use gumdrop::{Options, ParsingStyle};
@@ -354,7 +354,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
+                .decrypt(identities.into_iter())
                 .map_err(|e| e.into())
                 .and_then(|input| write_output(input, output))
         }

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -354,7 +354,12 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
+                .decrypt_with_callbacks(
+                    identities
+                        .into_iter()
+                        .map(|i| Box::new(i) as Box<dyn age::Identity>),
+                    &UiCallbacks,
+                )
                 .map_err(|e| e.into())
                 .and_then(|input| write_output(input, output))
         }

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -354,7 +354,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(&identities, &UiCallbacks)
+                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
                 .map_err(|e| e.into())
                 .and_then(|input| write_output(input, output))
         }

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -354,12 +354,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             )?;
 
             decryptor
-                .decrypt_with_callbacks(
-                    identities
-                        .into_iter()
-                        .map(|i| Box::new(i) as Box<dyn age::Identity>),
-                    &UiCallbacks,
-                )
+                .decrypt_with_callbacks(identities.into_iter(), &UiCallbacks)
                 .map_err(|e| e.into())
                 .and_then(|input| write_output(input, output))
         }


### PR DESCRIPTION
This decouples the identity implementations from the age library, enabling external implementations of identities (leveraging the flexibility of the age format's single joint).

Part of #99.