### PR TITLE
Move more core structs into age-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "cookie-factory 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secrecy 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -8,6 +8,10 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 ### Added
+- Several structs used when implementing the `age::Identity` and
+  `age::Recipient` traits:
+  - `age_core::format::FileKey`
+  - `age_core::format::Stanza`
 - `age_core::primitives::{aead_decrypt, aead_encrypt, hkdf}`, to enable these
   common primitives to be reused in plugins.
 

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -27,3 +27,6 @@ sha2 = "0.9"
 # Parsing
 cookie-factory = "0.3.1"
 nom = "5"
+
+# Secret management
+secrecy = "0.7"

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -12,6 +12,30 @@ pub struct AgeStanza<'a> {
     pub body: Vec<u8>,
 }
 
+/// A section of the age header that encapsulates the file key as encrypted to a specific
+/// recipient.
+#[derive(Debug)]
+pub struct Stanza {
+    /// A tag identifying this stanza type.
+    pub tag: String,
+    /// Zero or more arguments.
+    pub args: Vec<String>,
+    /// The body of the stanza, containing a wrapped [`FileKey`].
+    ///
+    /// [`FileKey`]: crate::keys::FileKey
+    pub body: Vec<u8>,
+}
+
+impl From<AgeStanza<'_>> for Stanza {
+    fn from(stanza: AgeStanza<'_>) -> Self {
+        Stanza {
+            tag: stanza.tag.to_string(),
+            args: stanza.args.into_iter().map(|s| s.to_string()).collect(),
+            body: stanza.body,
+        }
+    }
+}
+
 pub mod read {
     use nom::{
         bytes::streaming::{tag, take_while1},

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -1,3 +1,20 @@
+use secrecy::{ExposeSecret, Secret};
+
+/// A file key for encrypting or decrypting an age file.
+pub struct FileKey(Secret<[u8; 16]>);
+
+impl From<[u8; 16]> for FileKey {
+    fn from(file_key: [u8; 16]) -> Self {
+        FileKey(Secret::new(file_key))
+    }
+}
+
+impl ExposeSecret<[u8; 16]> for FileKey {
+    fn expose_secret(&self) -> &[u8; 16] {
+        self.0.expose_secret()
+    }
+}
+
 /// From the age spec:
 /// ```text
 /// Each recipient stanza starts with a line beginning with -> and its type name, followed
@@ -21,8 +38,6 @@ pub struct Stanza {
     /// Zero or more arguments.
     pub args: Vec<String>,
     /// The body of the stanza, containing a wrapped [`FileKey`].
-    ///
-    /// [`FileKey`]: crate::keys::FileKey
     pub body: Vec<u8>,
 }
 

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -15,22 +15,24 @@ impl ExposeSecret<[u8; 16]> for FileKey {
     }
 }
 
-/// From the age spec:
-/// ```text
-/// Each recipient stanza starts with a line beginning with -> and its type name, followed
-/// by zero or more SP-separated arguments. The type name and the arguments are arbitrary
-/// strings. Unknown recipient types are ignored. The rest of the recipient stanza is a
-/// body of canonical base64 from RFC 4648 without padding wrapped at exactly 64 columns.
-/// ```
+/// A section of the age header that encapsulates the file key as encrypted to a specific
+/// recipient.
+///
+/// This is the reference type; see [`Stanza`] for the owned type.
 #[derive(Debug)]
 pub struct AgeStanza<'a> {
+    /// A tag identifying this stanza type.
     pub tag: &'a str,
+    /// Zero or more arguments.
     pub args: Vec<&'a str>,
+    /// The body of the stanza, containing a wrapped [`FileKey`].
     pub body: Vec<u8>,
 }
 
 /// A section of the age header that encapsulates the file key as encrypted to a specific
 /// recipient.
+///
+/// This is the owned type; see [`AgeStanza`] for the reference type.
 #[derive(Debug)]
 pub struct Stanza {
     /// A tag identifying this stanza type.
@@ -105,6 +107,15 @@ pub mod read {
     }
 
     /// Reads an age stanza.
+    ///
+    /// From the age spec:
+    /// ```text
+    /// Each recipient stanza starts with a line beginning with -> and its type name,
+    /// followed by zero or more SP-separated arguments. The type name and the arguments
+    /// are arbitrary strings. Unknown recipient types are ignored. The rest of the
+    /// recipient stanza is a body of canonical base64 from RFC 4648 without padding
+    /// wrapped at exactly 64 columns.
+    /// ```
     pub fn age_stanza<'a>(input: &'a [u8]) -> IResult<&'a [u8], AgeStanza<'a>> {
         map(
             pair(

--- a/age-core/src/lib.rs
+++ b/age-core/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+// Catch documentation errors caused by code changes.
+#![deny(intra_doc_link_resolution_failure)]
 
 pub mod format;
 pub mod primitives;

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -29,9 +29,6 @@ to 1.0.0 are beta releases.
     a potentially-armored age file.
   - `age::armor::ArmoredWriter`, which can be wrapped around an output to
     optionally apply the armored age format.
-- Several structs used when implementing the `age::Identity` trait:
-  - `age::FileKey`
-  - `age::RecipientStanza`
 
 ### Changed
 - MSRV is now 1.39.0.

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -173,10 +173,7 @@ mod read {
     use crate::util::read::base64_arg;
 
     fn recipient_stanza(input: &[u8]) -> IResult<&[u8], Stanza> {
-        preceded(
-            tag(RECIPIENT_TAG),
-            map(age_stanza, Stanza::from),
-        )(input)
+        preceded(tag(RECIPIENT_TAG), map(age_stanza, Stanza::from))(input)
     }
 
     fn header_v1(input: &[u8]) -> IResult<&[u8], HeaderV1> {

--- a/age/src/identity.rs
+++ b/age/src/identity.rs
@@ -1,7 +1,8 @@
+use age_core::format::Stanza;
 use std::fs::File;
 use std::io;
 
-use crate::{error::Error, format::RecipientStanza, keys::FileKey, x25519, Identity};
+use crate::{error::Error, keys::FileKey, x25519, Identity};
 
 /// A list of identities that has been parsed from some input file.
 pub struct IdentityFile {
@@ -56,7 +57,7 @@ impl IdentityFile {
 }
 
 impl Identity for IdentityFile {
-    fn unwrap_file_key(&self, stanza: &RecipientStanza) -> Option<Result<FileKey, Error>> {
+    fn unwrap_file_key(&self, stanza: &Stanza) -> Option<Result<FileKey, Error>> {
         self.identities
             .iter()
             .find_map(|identity| identity.unwrap_file_key(stanza))

--- a/age/src/identity.rs
+++ b/age/src/identity.rs
@@ -1,8 +1,8 @@
-use age_core::format::Stanza;
+use age_core::format::{FileKey, Stanza};
 use std::fs::File;
 use std::io;
 
-use crate::{error::Error, keys::FileKey, x25519, Identity};
+use crate::{error::Error, x25519, Identity};
 
 /// A list of identities that has been parsed from some input file.
 pub struct IdentityFile {

--- a/age/src/keys.rs
+++ b/age/src/keys.rs
@@ -1,6 +1,6 @@
 //! Key structs and serialization.
 
-use age_core::primitives::hkdf;
+use age_core::{format::FileKey, primitives::hkdf};
 use rand::{rngs::OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret};
 
@@ -14,47 +14,30 @@ use crate::{
 const HEADER_KEY_LABEL: &[u8] = b"header";
 const PAYLOAD_KEY_LABEL: &[u8] = b"payload";
 
-/// A file key for encrypting or decrypting an age file.
-pub struct FileKey(Secret<[u8; 16]>);
-
-impl From<[u8; 16]> for FileKey {
-    fn from(file_key: [u8; 16]) -> Self {
-        FileKey(Secret::new(file_key))
-    }
+pub(crate) fn new_file_key() -> FileKey {
+    let mut file_key = [0; 16];
+    OsRng.fill_bytes(&mut file_key);
+    file_key.into()
 }
 
-impl ExposeSecret<[u8; 16]> for FileKey {
-    fn expose_secret(&self) -> &[u8; 16] {
-        self.0.expose_secret()
-    }
+pub(crate) fn mac_key(file_key: &FileKey) -> HmacKey {
+    HmacKey(Secret::new(hkdf(
+        &[],
+        HEADER_KEY_LABEL,
+        file_key.expose_secret(),
+    )))
 }
 
-impl FileKey {
-    pub(crate) fn generate() -> Self {
-        let mut file_key = [0; 16];
-        OsRng.fill_bytes(&mut file_key);
-        file_key.into()
-    }
+pub(crate) fn v1_payload_key(
+    file_key: &FileKey,
+    header: &HeaderV1,
+    nonce: &Nonce,
+) -> Result<PayloadKey, Error> {
+    // Verify the MAC
+    header.verify_mac(mac_key(file_key))?;
 
-    pub(crate) fn mac_key(&self) -> HmacKey {
-        HmacKey(Secret::new(hkdf(
-            &[],
-            HEADER_KEY_LABEL,
-            self.0.expose_secret(),
-        )))
-    }
-
-    pub(crate) fn v1_payload_key(
-        &self,
-        header: &HeaderV1,
-        nonce: &Nonce,
-    ) -> Result<PayloadKey, Error> {
-        // Verify the MAC
-        header.verify_mac(self.mac_key())?;
-
-        // Return the payload key
-        Ok(PayloadKey(
-            hkdf(nonce.as_ref(), PAYLOAD_KEY_LABEL, self.0.expose_secret()).into(),
-        ))
-    }
+    // Return the payload key
+    Ok(PayloadKey(
+        hkdf(nonce.as_ref(), PAYLOAD_KEY_LABEL, file_key.expose_secret()).into(),
+    ))
 }

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -130,7 +130,6 @@ mod util;
 pub mod x25519;
 
 pub use error::Error;
-pub use format::RecipientStanza as Stanza;
 pub use identity::IdentityFile;
 pub use keys::FileKey;
 pub use primitives::stream;
@@ -146,6 +145,8 @@ pub mod cli_common;
 #[cfg(feature = "ssh")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ssh")))]
 pub mod ssh;
+
+use age_core::format::Stanza;
 
 /// A private key or other value that can unwrap an opaque file key from a recipient
 /// stanza.
@@ -163,7 +164,7 @@ pub trait Identity {
     ///
     /// [one joint]: https://www.imperialviolet.org/2016/05/16/agility.html
     /// [`RecipientsDecryptor::decrypt`]: protocol::decryptor::RecipientsDecryptor::decrypt
-    fn unwrap_file_key(&self, stanza: &format::RecipientStanza) -> Option<Result<FileKey, Error>>;
+    fn unwrap_file_key(&self, stanza: &Stanza) -> Option<Result<FileKey, Error>>;
 }
 
 /// A public key or other value that can wrap an opaque file key to a recipient stanza.
@@ -176,7 +177,7 @@ pub trait Recipient {
     /// recipients to [`Encryptor::with_recipients`].
     ///
     /// [one joint]: https://www.imperialviolet.org/2016/05/16/agility.html
-    fn wrap_file_key(&self, file_key: &FileKey) -> format::RecipientStanza;
+    fn wrap_file_key(&self, file_key: &FileKey) -> Stanza;
 }
 
 /// Helper for fuzzing the Header parser and serializer.

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -131,7 +131,6 @@ pub mod x25519;
 
 pub use error::Error;
 pub use identity::IdentityFile;
-pub use keys::FileKey;
 pub use primitives::stream;
 pub use protocol::{decryptor, Decryptor, Encryptor};
 
@@ -146,7 +145,7 @@ pub mod cli_common;
 #[cfg_attr(docsrs, doc(cfg(feature = "ssh")))]
 pub mod ssh;
 
-use age_core::format::Stanza;
+use age_core::format::{FileKey, Stanza};
 
 /// A private key or other value that can unwrap an opaque file key from a recipient
 /// stanza.

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -8,7 +8,7 @@ use std::iter;
 use crate::{
     error::Error,
     format::{oil_the_joint, Header, HeaderV1},
-    keys::FileKey,
+    keys::{mac_key, new_file_key, v1_payload_key},
     primitives::stream::{PayloadKey, Stream, StreamWriter},
     scrypt, Recipient,
 };
@@ -78,7 +78,7 @@ impl Encryptor {
 
     /// Creates the header for this age file.
     fn prepare_header(self) -> (Header, Nonce, PayloadKey) {
-        let file_key = FileKey::generate();
+        let file_key = new_file_key();
 
         let recipients = match self.0 {
             EncryptorType::Keys(recipients) => recipients
@@ -92,11 +92,9 @@ impl Encryptor {
             }
         };
 
-        let header = HeaderV1::new(recipients, file_key.mac_key());
+        let header = HeaderV1::new(recipients, mac_key(&file_key));
         let nonce = Nonce::random();
-        let payload_key = file_key
-            .v1_payload_key(&header, &nonce)
-            .expect("MAC is correct");
+        let payload_key = v1_payload_key(&file_key, &header, &nonce).expect("MAC is correct");
 
         (Header::V1(header), nonce, payload_key)
     }

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -1,12 +1,13 @@
 //! Decryptors for age.
 
+use age_core::format::Stanza;
 use secrecy::SecretString;
 use std::io::Read;
 
 use super::Nonce;
 use crate::{
     error::Error,
-    format::{Header, RecipientStanza},
+    format::Header,
     keys::FileKey,
     primitives::stream::{PayloadKey, Stream, StreamReader},
     scrypt, Identity,
@@ -27,7 +28,7 @@ struct BaseDecryptor<R> {
 impl<R> BaseDecryptor<R> {
     fn obtain_payload_key<F>(&self, filter: F) -> Result<PayloadKey, Error>
     where
-        F: FnMut(&RecipientStanza) -> Option<Result<FileKey, Error>>,
+        F: FnMut(&Stanza) -> Option<Result<FileKey, Error>>,
     {
         match &self.header {
             Header::V1(header) => header

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -1,6 +1,6 @@
 //! Decryptors for age.
 
-use age_core::format::Stanza;
+use age_core::format::{FileKey, Stanza};
 use secrecy::SecretString;
 use std::io::Read;
 
@@ -8,7 +8,7 @@ use super::Nonce;
 use crate::{
     error::Error,
     format::Header,
-    keys::FileKey,
+    keys::v1_payload_key,
     primitives::stream::{PayloadKey, Stream, StreamReader},
     scrypt, Identity,
 };
@@ -36,7 +36,7 @@ impl<R> BaseDecryptor<R> {
                 .iter()
                 .find_map(filter)
                 .unwrap_or(Err(Error::NoMatchingKeys))
-                .and_then(|file_key| file_key.v1_payload_key(header, &self.nonce)),
+                .and_then(|file_key| v1_payload_key(&file_key, header, &self.nonce)),
             Header::Unknown(_) => unreachable!(),
         }
     }

--- a/age/src/scrypt.rs
+++ b/age/src/scrypt.rs
@@ -1,5 +1,5 @@
 use age_core::{
-    format::Stanza,
+    format::{FileKey, Stanza},
     primitives::{aead_decrypt, aead_encrypt},
 };
 use rand::{rngs::OsRng, RngCore};
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 use std::time::Duration;
 use zeroize::Zeroize;
 
-use crate::{error::Error, keys::FileKey, primitives::scrypt, util::read::base64_arg};
+use crate::{error::Error, primitives::scrypt, util::read::base64_arg};
 
 pub(super) const SCRYPT_RECIPIENT_TAG: &str = "scrypt";
 const SCRYPT_SALT_LABEL: &[u8] = b"age-encryption.org/v1/scrypt";

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -1,5 +1,5 @@
 use age_core::{
-    format::Stanza,
+    format::{FileKey, Stanza},
     primitives::{aead_decrypt, hkdf},
 };
 use nom::{
@@ -26,7 +26,6 @@ use super::{
 };
 use crate::{
     error::Error,
-    keys::FileKey,
     protocol::decryptor::Callbacks,
     util::read::{base64_arg, wrapped_str_while_encoded},
 };

--- a/age/src/ssh/recipient.rs
+++ b/age/src/ssh/recipient.rs
@@ -1,5 +1,5 @@
 use age_core::{
-    format::Stanza,
+    format::{FileKey, Stanza},
     primitives::{aead_encrypt, hkdf},
 };
 use curve25519_dalek::edwards::EdwardsPoint;
@@ -21,10 +21,7 @@ use super::{
     read_ssh, ssh_tag, SSH_ED25519_KEY_PREFIX, SSH_ED25519_RECIPIENT_KEY_LABEL,
     SSH_ED25519_RECIPIENT_TAG, SSH_RSA_KEY_PREFIX, SSH_RSA_OAEP_LABEL, SSH_RSA_RECIPIENT_TAG,
 };
-use crate::{
-    keys::FileKey,
-    util::read::{encoded_str, str_while_encoded},
-};
+use crate::util::read::{encoded_str, str_while_encoded};
 
 /// A key that can be used to encrypt a file to a recipient.
 #[derive(Clone, Debug)]

--- a/age/src/ssh/recipient.rs
+++ b/age/src/ssh/recipient.rs
@@ -1,4 +1,7 @@
-use age_core::primitives::{aead_encrypt, hkdf};
+use age_core::{
+    format::Stanza,
+    primitives::{aead_encrypt, hkdf},
+};
 use curve25519_dalek::edwards::EdwardsPoint;
 use nom::{
     branch::alt,
@@ -19,7 +22,6 @@ use super::{
     SSH_ED25519_RECIPIENT_TAG, SSH_RSA_KEY_PREFIX, SSH_RSA_OAEP_LABEL, SSH_RSA_RECIPIENT_TAG,
 };
 use crate::{
-    format::RecipientStanza,
     keys::FileKey,
     util::read::{encoded_str, str_while_encoded},
 };
@@ -71,7 +73,7 @@ impl fmt::Display for Recipient {
 }
 
 impl crate::Recipient for Recipient {
-    fn wrap_file_key(&self, file_key: &FileKey) -> RecipientStanza {
+    fn wrap_file_key(&self, file_key: &FileKey) -> Stanza {
         match self {
             Recipient::SshRsa(ssh_key, pk) => {
                 let mut rng = OsRng;
@@ -87,7 +89,7 @@ impl crate::Recipient for Recipient {
                 let encoded_tag =
                     base64::encode_config(&ssh_tag(&ssh_key), base64::STANDARD_NO_PAD);
 
-                RecipientStanza {
+                Stanza {
                     tag: SSH_RSA_RECIPIENT_TAG.to_owned(),
                     args: vec![encoded_tag],
                     body: encrypted_file_key,
@@ -120,7 +122,7 @@ impl crate::Recipient for Recipient {
                     base64::encode_config(&ssh_tag(&ssh_key), base64::STANDARD_NO_PAD);
                 let encoded_epk = base64::encode_config(epk.as_bytes(), base64::STANDARD_NO_PAD);
 
-                RecipientStanza {
+                Stanza {
                     tag: SSH_ED25519_RECIPIENT_TAG.to_owned(),
                     args: vec![encoded_tag, encoded_epk],
                     body: encrypted_file_key,

--- a/age/src/x25519.rs
+++ b/age/src/x25519.rs
@@ -1,6 +1,9 @@
 //! The "x25519" recipient type, native to age.
 
-use age_core::primitives::{aead_decrypt, aead_encrypt, hkdf};
+use age_core::{
+    format::Stanza,
+    primitives::{aead_decrypt, aead_encrypt, hkdf},
+};
 use bech32::{FromBase32, ToBase32};
 use rand::rngs::OsRng;
 use secrecy::ExposeSecret;
@@ -69,10 +72,7 @@ impl Identity {
 }
 
 impl crate::Identity for Identity {
-    fn unwrap_file_key(
-        &self,
-        stanza: &crate::format::RecipientStanza,
-    ) -> Option<Result<FileKey, Error>> {
+    fn unwrap_file_key(&self, stanza: &Stanza) -> Option<Result<FileKey, Error>> {
         if stanza.tag != X25519_RECIPIENT_TAG {
             return None;
         }
@@ -134,7 +134,7 @@ impl fmt::Display for Recipient {
 }
 
 impl crate::Recipient for Recipient {
-    fn wrap_file_key(&self, file_key: &FileKey) -> crate::format::RecipientStanza {
+    fn wrap_file_key(&self, file_key: &FileKey) -> Stanza {
         let mut rng = OsRng;
         let esk = EphemeralSecret::new(&mut rng);
         let epk: PublicKey = (&esk).into();
@@ -149,7 +149,7 @@ impl crate::Recipient for Recipient {
 
         let encoded_epk = base64::encode_config(epk.as_bytes(), base64::STANDARD_NO_PAD);
 
-        crate::format::RecipientStanza {
+        Stanza {
             tag: X25519_RECIPIENT_TAG.to_owned(),
             args: vec![encoded_epk],
             body: encrypted_file_key,

--- a/age/src/x25519.rs
+++ b/age/src/x25519.rs
@@ -1,7 +1,7 @@
 //! The "x25519" recipient type, native to age.
 
 use age_core::{
-    format::Stanza,
+    format::{FileKey, Stanza},
     primitives::{aead_decrypt, aead_encrypt, hkdf},
 };
 use bech32::{FromBase32, ToBase32};
@@ -13,7 +13,7 @@ use std::fmt;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 use zeroize::Zeroize;
 
-use crate::{error::Error, keys::FileKey, util::read::base64_arg};
+use crate::{error::Error, util::read::base64_arg};
 
 // Use lower-case HRP to avoid https://github.com/rust-bitcoin/rust-bech32/issues/40
 const SECRET_KEY_PREFIX: &str = "age-secret-key-";


### PR DESCRIPTION
`Stanza` and `FileKey` are in the public API for implementations, but are unnecessary for users.