### PR TITLE
Remove support for a default identity (or alias) path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,6 @@ dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
  "curve25519-dalek",
- "dirs",
  "futures",
  "futures-test",
  "hkdf",
@@ -125,12 +124,6 @@ checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
@@ -200,17 +193,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block"
@@ -454,12 +436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "cookie-factory"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -543,7 +519,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -554,21 +530,10 @@ checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -653,26 +618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "dirs"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1711,7 +1656,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -1721,17 +1666,6 @@ name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
-]
 
 [[package]]
 name = "regex"
@@ -1832,18 +1766,6 @@ dependencies = [
  "subtle",
  "thiserror",
  "zeroize",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64 0.12.3",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils 0.7.2",
 ]
 
 [[package]]

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -65,6 +65,9 @@ to 1.0.0 are beta releases.
 - `age::decryptor::RecipientsDecryptor::decrypt_with_callbacks()` (identities
   are now expected to handle their own callbacks, and
   `age::cli_common::read_identities` now adds callbacks to SSH identities).
+- Default identity path:
+  - `age::cli_common::get_config_dir`.
+  - The `no_default` parameter for `age::cli_common::read_identities`.
 
 ## [0.4.0] - 2020-03-25
 ### Added

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -77,7 +77,6 @@ rust-embed = "5"
 
 # Common CLI dependencies
 console = { version = "0.13", optional = true }
-dirs = { version = "3.0.1", optional = true }
 pinentry = { version = "0.2", optional = true }
 rpassword = { version = "5", optional = true }
 
@@ -92,7 +91,7 @@ quickcheck_macros = "0.9"
 default = []
 armor = []
 async = ["futures"]
-cli-common = ["console", "dirs", "pinentry", "rpassword"]
+cli-common = ["console", "pinentry", "rpassword"]
 ssh = [
     "aes",
     "aes-ctr",

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -17,6 +17,10 @@ to 1.0.0 are beta releases.
 ### Changed
 - MSRV is now 1.45.0.
 
+### Removed
+- Default identity path (identities should instead be set per-use).
+- Default alias path (for unstable aliases feature).
+
 ## [0.4.0] - 2020-03-25
 ### Added
 - `rage-mount` can now mount ASCII-armored age files.

--- a/rage/examples/generate-docs.rs
+++ b/rage/examples/generate-docs.rs
@@ -104,13 +104,7 @@ fn rage_page() {
         )
         .example(
             Example::new()
-                .text("Decryption with identities at ~/.config/age/keys.txt")
-                .command("rage --decrypt hello.age")
-                .output("_o/"),
-        )
-        .example(
-            Example::new()
-                .text("Decryption with custom identities")
+                .text("Decryption with identities")
                 .command("rage -d -o hello -i keyA.txt -i keyB.txt hello.age"),
         );
     #[cfg(feature = "unstable")]
@@ -118,7 +112,7 @@ fn rage_page() {
         .option(
             Opt::new("ALIASES")
                 .long("--aliases")
-                .help("Load the aliases list from ALIASES. Defaults to ~/.config/age/aliases.txt"),
+                .help("Load the aliases list from ALIASES."),
         )
         .example(
             Example::new()
@@ -131,7 +125,7 @@ fn rage_page() {
         .example(
             Example::new()
                 .text("Encryption to an alias")
-                .command("tar cv ~/xxx | rage -r alias:str4d > xxx.tar.age"),
+                .command("tar cv ~/xxx | rage --aliases aliases.txt -r alias:str4d > xxx.tar.age"),
         );
     let page = builder.render();
 
@@ -209,12 +203,7 @@ fn rage_mount_page() {
         .arg(Arg::new("mountpoint"))
         .example(
             Example::new()
-                .text("Mounting an archive with keys at ~/.config/age/keys.txt")
-                .command("rage-mount -t zip encrypted.zip.age ./tmp"),
-        )
-        .example(
-            Example::new()
-                .text("Mounting an archive with custom keys")
+                .text("Mounting an archive encrypted to a recipient")
                 .command("rage-mount -t tar -i key.txt encrypted.tar.age ./tmp"),
         )
         .example(

--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -107,8 +107,7 @@ rec-dec-armor-flag = Note that armored files are detected automatically.
 err-dec-identity-not-found = Identity file not found: {$filename}
 
 err-dec-missing-identities = Missing identities.
-rec-dec-missing-identities-1 = Did you forget to specify {-flag-identity}?
-rec-dec-missing-identities-2 = You can also store default identities in this file:
+rec-dec-missing-identities = Did you forget to specify {-flag-identity}?
 
 err-dec-passphrase-flag = {-flag-passphrase} can't be used with {-flag-decrypt}.
 rec-dec-passphrase-flag = Note that passphrase-encrypted files are detected automatically.

--- a/rage/i18n/es-AR/rage.ftl
+++ b/rage/i18n/es-AR/rage.ftl
@@ -108,8 +108,7 @@ rec-dec-armor-flag = Nota que los archivos blindados son detectados automáticam
 err-dec-identity-not-found = Archivo identidad no encontrado: {$filename}
 
 err-dec-missing-identities = No se encontraron las identidades.
-rec-dec-missing-identities-1 = ¿Te olvidaste de especificar {-flag-identity}?
-rec-dec-missing-identities-2 = Tambien puedes guardar las identidades por defecto en este archivo:
+rec-dec-missing-identities = ¿Te olvidaste de especificar {-flag-identity}?
 
 err-dec-passphrase-flag = {-flag-passphrase} no puede ser usado con {-flag-decrypt}.
 rec-dec-passphrase-flag = Nota que los archivos encriptados con frases contraseñas son detectados automáticamente.

--- a/rage/i18n/it-IT/rage.ftl
+++ b/rage/i18n/it-IT/rage.ftl
@@ -109,8 +109,7 @@ rec-dec-armor-flag = Nota che i file armored vengono rilevati automaticamente.
 err-dec-identity-not-found = File di identità non trovato: {$filename}
 
 err-dec-missing-identities = Identità mancanti.
-rec-dec-missing-identities-1 = Hai dimenticato di specificare {-flag-identity}?
-rec-dec-missing-identities-2 = Puoi anche memorizzare le identità predefinite in questo file:
+rec-dec-missing-identities = Hai dimenticato di specificare {-flag-identity}?
 
 err-dec-passphrase-flag = {-flag-passphrase} non può essere usato assieme a {-flag-decrypt}.
 rec-dec-passphrase-flag = Nota che i file crittografati con la passphrase vengono rilevati automaticamente.

--- a/rage/i18n/zh-CN/rage.ftl
+++ b/rage/i18n/zh-CN/rage.ftl
@@ -106,8 +106,7 @@ rec-dec-armor-flag = 请注意，装甲文件 （armored files） 会被自动�
 err-dec-identity-not-found = 未搜索到身份文件： {$filename}
 
 err-dec-missing-identities = 缺少身份。
-rec-dec-missing-identities-1 = 您是否忘记指定 {-flag-identity} 标记？
-rec-dec-missing-identities-2 = 您即可在该文件内存放默认身份：
+rec-dec-missing-identities = 您是否忘记指定 {-flag-identity} 标记？
 
 err-dec-passphrase-flag = {-flag-passphrase} 和 {-flag-decrypt} 标记不可联用。
 rec-dec-passphrase-flag = 请注意，以密码短语加密的文件会被自动检测。

--- a/rage/i18n/zh-TW/rage.ftl
+++ b/rage/i18n/zh-TW/rage.ftl
@@ -106,8 +106,7 @@ rec-dec-armor-flag = 請注意，裝甲文件 （armored files） 會被自動�
 err-dec-identity-not-found = 未搜索到身份文件： {$filename}
 
 err-dec-missing-identities = 缺少身份。
-rec-dec-missing-identities-1 = 您是否忘記指定 {-flag-identity} 標記？
-rec-dec-missing-identities-2 = 您即可在該文件內存放默認身份：
+rec-dec-missing-identities = 您是否忘記指定 {-flag-identity} 標記？
 
 err-dec-passphrase-flag = {-flag-passphrase} 和 {-flag-decrypt} 標記不可聯用。
 rec-dec-passphrase-flag = 請注意，以密碼短語加密的文件會被自動檢測。

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -118,7 +118,7 @@ pub(crate) enum DecryptError {
     ArmorFlag,
     IdentityNotFound(String),
     Io(io::Error),
-    MissingIdentities(String),
+    MissingIdentities,
     PassphraseFlag,
     PassphraseTimedOut,
     #[cfg(not(unix))]
@@ -172,11 +172,9 @@ impl fmt::Display for DecryptError {
                 )
             ),
             DecryptError::Io(e) => write!(f, "{}", e),
-            DecryptError::MissingIdentities(default_filename) => {
+            DecryptError::MissingIdentities => {
                 wlnfl!(f, "err-dec-missing-identities")?;
-                wlnfl!(f, "rec-dec-missing-identities-1")?;
-                wlnfl!(f, "rec-dec-missing-identities-2")?;
-                write!(f, "    {}", default_filename)
+                wlnfl!(f, "rec-dec-missing-identities")
             }
             DecryptError::PassphraseFlag => {
                 wlnfl!(f, "err-dec-passphrase-flag")?;

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -45,7 +45,7 @@ macro_rules! fl {
 /// Returns an error if a filename is given that does not exist.
 fn load_aliases(filename: Option<String>) -> io::Result<HashMap<String, Vec<String>>> {
     let buf = filename
-        .map(|f| read_to_string(f))
+        .map(read_to_string)
         .transpose()?
         .unwrap_or_default();
 
@@ -389,7 +389,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             )?;
 
             if identities.is_empty() {
-                Err(error::DecryptError::MissingIdentities)?;
+                return Err(error::DecryptError::MissingIdentities);
             }
 
             decryptor

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -2,10 +2,7 @@
 
 use age::{
     armor::{ArmoredReader, ArmoredWriter, Format},
-    cli_common::{
-        file_io, get_config_dir, read_identities, read_or_generate_passphrase, read_secret,
-        Passphrase,
-    },
+    cli_common::{file_io, read_identities, read_or_generate_passphrase, read_secret, Passphrase},
     Recipient,
 };
 use gumdrop::{Options, ParsingStyle};
@@ -43,23 +40,14 @@ macro_rules! fl {
     }};
 }
 
-/// Load map of aliases from the given file, or the default system location
-/// otherwise.
+/// Loads a map of aliases from the given file, if any.
 ///
-/// Returns an error if a filename is given that does not exist. A missing
-/// aliases file at the default system location is ignored.
+/// Returns an error if a filename is given that does not exist.
 fn load_aliases(filename: Option<String>) -> io::Result<HashMap<String, Vec<String>>> {
-    let buf = if let Some(f) = filename {
-        read_to_string(f)?
-    } else {
-        // If the default aliases file doesn't exist, ignore it.
-        get_config_dir()
-            .map(|mut path| {
-                path.push("age/aliases.txt");
-                read_to_string(path).unwrap_or_default()
-            })
-            .unwrap_or_default()
-    };
+    let buf = filename
+        .map(|f| read_to_string(f))
+        .transpose()?
+        .unwrap_or_default();
 
     let mut aliases = HashMap::new();
 
@@ -395,13 +383,14 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
         age::Decryptor::Recipients(decryptor) => {
             let identities = read_identities(
                 opts.identity,
-                |default_filename| {
-                    error::DecryptError::MissingIdentities(default_filename.to_string())
-                },
                 error::DecryptError::IdentityNotFound,
                 #[cfg(feature = "ssh")]
                 error::DecryptError::UnsupportedKey,
             )?;
+
+            if identities.is_empty() {
+                Err(error::DecryptError::MissingIdentities)?;
+            }
 
             decryptor
                 .decrypt(identities.into_iter())


### PR DESCRIPTION
Instead of configuring defaults, users should specify identity files directly.