### PR TITLE
rage: Disable log output by default

### DIFF
--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Fixed
+- Log output is now disabled by default, to prevent non-fatal error messages
+  (such as an unset or invalid `LANG` variable) being printed to stderr while
+  the program succeeds (which is confusing for users). The previous behaviour
+  can be configured by setting the environment variable `RUST_LOG=error`.
 
 ## [0.5.0] - 2020-11-22
 ### Added

--- a/rage/src/bin/rage-keygen/main.rs
+++ b/rage/src/bin/rage-keygen/main.rs
@@ -41,7 +41,11 @@ struct AgeOptions {
 }
 
 fn main() {
-    env_logger::builder().format_timestamp(None).init();
+    env_logger::builder()
+        .format_timestamp(None)
+        .filter_level(log::LevelFilter::Off)
+        .parse_default_env()
+        .init();
 
     let requested_languages = DesktopLanguageRequester::requested_languages();
     i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -199,7 +199,11 @@ fn mount_stream(
 fn main() -> Result<(), Error> {
     use std::env::args;
 
-    env_logger::builder().format_timestamp(None).init();
+    env_logger::builder()
+        .format_timestamp(None)
+        .filter_level(log::LevelFilter::Off)
+        .parse_default_env()
+        .init();
 
     let requested_languages = DesktopLanguageRequester::requested_languages();
     i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -403,7 +403,11 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
 fn main() -> Result<(), error::Error> {
     use std::env::args;
 
-    env_logger::builder().format_timestamp(None).init();
+    env_logger::builder()
+        .format_timestamp(None)
+        .filter_level(log::LevelFilter::Off)
+        .parse_default_env()
+        .init();
 
     let requested_languages = DesktopLanguageRequester::requested_languages();
     i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();


### PR DESCRIPTION
Log output can be enabled with the `RUST_LOG` environment variable.

Closes str4d/rage#156