### PR TITLE
Allow overwriting existing output file

### DIFF
--- a/age/src/cli_common/file_io.rs
+++ b/age/src/cli_common/file_io.rs
@@ -183,7 +183,7 @@ impl LazyFile {
 
         if self.file.is_none() {
             let mut options = OpenOptions::new();
-            options.write(true).create_new(true);
+            options.write(true).create(true).truncate(true);
 
             #[cfg(unix)]
             options.mode(self.mode);
@@ -268,5 +268,20 @@ impl Write for OutputWriter {
             OutputWriter::File(f) => f.flush(),
             OutputWriter::Stdout(handle) => handle.flush(),
         }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{OutputFormat, OutputWriter};
+    use std::io::Write;
+
+    #[cfg(unix)]
+    #[test]
+    fn lazy_existing_file() {
+        OutputWriter::new(Some("/dev/null".to_string()), OutputFormat::Text, 0o600)
+            .unwrap()
+            .flush()
+            .unwrap();
     }
 }

--- a/age/src/cli_common/file_io.rs
+++ b/age/src/cli_common/file_io.rs
@@ -273,7 +273,9 @@ impl Write for OutputWriter {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    #[cfg(unix)]
     use super::{OutputFormat, OutputWriter};
+    #[cfg(unix)]
     use std::io::Write;
 
     #[cfg(unix)]


### PR DESCRIPTION
Otherwise, `rage` fails with:
```bash 
$ echo | rage -r age100qf7fggvctqclsqvl2xu6vjnrerxm9vt8x56yql6gaz9x54vcaqdh2q26 -o existing-file.age
Error: File exists (os error 17)
```