### PR TITLE
age: Ignore all unsupported SSH pubkey types

### DIFF
--- a/age/src/ssh.rs
+++ b/age/src/ssh.rs
@@ -295,7 +295,7 @@ mod read_ssh {
     }
 
     /// Recognizes an SSH `string` matching a tag.
-    pub fn string_tag(value: &'static str) -> impl Fn(&[u8]) -> IResult<&[u8], &[u8]> {
+    pub fn string_tag<'a>(value: &'a str) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
         move |input: &[u8]| length_value(be_u32, tag(value))(input)
     }
 


### PR DESCRIPTION
Instead of hard-coding the list, we rely on the invariant that all SSH
pubkeys have the form `key_type Base64(string(key_type) || ...)`.