### PR TITLE
age: Open files lazily in age::cli_common::file_io::OutputWriter

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -14,6 +14,9 @@ to 1.0.0 are beta releases.
   beta versions, due to changes in how stanza bodies are canonically encoded.
   This should only affect a small fraction of files (if grease that triggers the
   change is added, which has a 3% chance per file).
+- `age::cli_common::file_io::OutputWriter::File` now wraps a `LazyFile` struct
+  (instead of wrapping `std::io::File` directly), which does not open the file
+  until it is first written to.
 
 ## [0.5.0] - 2020-11-22
 ### Added

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -29,6 +29,8 @@ to 1.0.0 are beta releases.
   (such as an unset or invalid `LANG` variable) being printed to stderr while
   the program succeeds (which is confusing for users). The previous behaviour
   can be configured by setting the environment variable `RUST_LOG=error`.
+- Output files are now opened lazily, which avoids leaving behind an empty file
+  when an error occurs before we write the header.
 
 ## [0.5.0] - 2020-11-22
 ### Added


### PR DESCRIPTION
This avoids rage leaving behind an empty file when an error occurs before
we write the header.