### PR TITLE
Plugin protocol updates

### DIFF
--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -9,6 +9,9 @@ to 1.0.0 are beta releases.
 ## [Unreleased]
 ### Added
 - `age_core::format::FILE_KEY_BYTES` constant.
+- `age_core::plugin` module, which contains common backend logic used by both
+  the `age` library (to implement client support for plugins) and the
+  `age-plugin` library.
 
 ### Changed
 - The stanza prefix `-> ` and trailing newline are now formal parts of the age

--- a/age-core/src/plugin.rs
+++ b/age-core/src/plugin.rs
@@ -23,9 +23,10 @@ const RESPONSE_UNSUPPORTED: &str = "unsupported";
 ///   should explicitly handle.
 pub type Result<T, E> = io::Result<std::result::Result<T, E>>;
 
-type UnidirResult<A, B, E> = io::Result<(
+type UnidirResult<A, B, C, E> = io::Result<(
     std::result::Result<Vec<A>, Vec<E>>,
     std::result::Result<Vec<B>, Vec<E>>,
+    Option<std::result::Result<Vec<C>, Vec<E>>>,
 )>;
 
 /// A connection to a plugin binary.
@@ -161,19 +162,23 @@ impl<R: Read, W: Write> Connection<R, W> {
     ///
     /// # Arguments
     ///
-    /// `command_a` and `command_b` are the known commands that are expected to be
-    /// received. All other received commands (including grease) will be ignored.
-    pub fn unidir_receive<A, B, E, F, G>(
+    /// `command_a`, `command_b`, and (optionally) `command_c` are the known commands that
+    /// are expected to be received. All other received commands (including grease) will
+    /// be ignored.
+    pub fn unidir_receive<A, B, C, E, F, G, H>(
         &mut self,
         command_a: (&str, F),
         command_b: (&str, G),
-    ) -> UnidirResult<A, B, E>
+        command_c: (Option<&str>, H),
+    ) -> UnidirResult<A, B, C, E>
     where
         F: Fn(Stanza) -> std::result::Result<A, E>,
         G: Fn(Stanza) -> std::result::Result<B, E>,
+        H: Fn(Stanza) -> std::result::Result<C, E>,
     {
         let mut res_a = Ok(vec![]);
         let mut res_b = Ok(vec![]);
+        let mut res_c = Ok(vec![]);
 
         for stanza in iter::repeat_with(|| self.receive()).take_while(|res| match res {
             Ok(stanza) => stanza.tag != COMMAND_DONE,
@@ -203,10 +208,14 @@ impl<R: Read, W: Write> Connection<R, W> {
                 validate(command_a.1(stanza), &mut res_a)
             } else if stanza.tag.as_str() == command_b.0 {
                 validate(command_b.1(stanza), &mut res_b)
+            } else if let Some(tag) = command_c.0 {
+                if stanza.tag.as_str() == tag {
+                    validate(command_c.1(stanza), &mut res_c)
+                }
             }
         }
 
-        Ok((res_a, res_b))
+        Ok((res_a, res_b, command_c.0.map(|_| res_c)))
     }
 
     /// Runs a bidirectional phase as the controller.
@@ -420,7 +429,11 @@ mod tests {
             .unidir_send(|mut phase| phase.send("test", &["foo"], b"bar"))
             .unwrap();
         let stanza = plugin_conn
-            .unidir_receive::<_, (), _, _, _>(("test", |s| Ok(s)), ("other", |_| Err(())))
+            .unidir_receive::<_, (), (), _, _, _, _>(
+                ("test", |s| Ok(s)),
+                ("other", |_| Err(())),
+                (None, |_| Ok(())),
+            )
             .unwrap();
         assert_eq!(
             stanza,
@@ -430,7 +443,8 @@ mod tests {
                     args: vec!["foo".to_owned()],
                     body: b"bar"[..].to_owned()
                 }]),
-                Ok(vec![])
+                Ok(vec![]),
+                None
             )
         );
     }

--- a/age-plugin/examples/age-plugin-unencrypted.rs
+++ b/age-plugin/examples/age-plugin-unencrypted.rs
@@ -67,19 +67,25 @@ impl RecipientPluginV1 for RecipientPlugin {
         }
     }
 
-    fn wrap_file_key(
+    fn wrap_file_keys(
         &mut self,
-        file_key: &FileKey,
+        file_keys: Vec<FileKey>,
         mut callbacks: impl Callbacks<recipient::Error>,
-    ) -> io::Result<Result<Vec<Stanza>, Vec<recipient::Error>>> {
+    ) -> io::Result<Result<Vec<Vec<Stanza>>, Vec<recipient::Error>>> {
         // A real plugin would wrap the file key here.
         let _ = callbacks
             .message("This plugin doesn't have any recipient-specific logic. It's unencrypted!")?;
-        Ok(Ok(vec![Stanza {
-            tag: RECIPIENT_TAG.to_owned(),
-            args: vec!["does".to_owned(), "nothing".to_owned()],
-            body: file_key.expose_secret().to_vec(),
-        }]))
+        Ok(Ok(file_keys
+            .into_iter()
+            .map(|file_key| {
+                // TODO: This should return one stanza per recipient and identity.
+                vec![Stanza {
+                    tag: RECIPIENT_TAG.to_owned(),
+                    args: vec!["does".to_owned(), "nothing".to_owned()],
+                    body: file_key.expose_secret().to_vec(),
+                }]
+            })
+            .collect()))
     }
 }
 

--- a/age-plugin/examples/age-plugin-unencrypted.rs
+++ b/age-plugin/examples/age-plugin-unencrypted.rs
@@ -42,6 +42,31 @@ impl RecipientPluginV1 for RecipientPlugin {
         }
     }
 
+    fn add_identities<'a, I: Iterator<Item = &'a str>>(
+        &mut self,
+        identities: I,
+    ) -> Result<(), Vec<recipient::Error>> {
+        let errors = identities
+            .enumerate()
+            .filter_map(|(index, identity)| {
+                if identity.contains(&PLUGIN_NAME.to_uppercase()) {
+                    // A real plugin would store the identity.
+                    None
+                } else {
+                    Some(recipient::Error::Identity {
+                        index,
+                        message: "invalid identity".to_owned(),
+                    })
+                }
+            })
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
     fn wrap_file_key(
         &mut self,
         file_key: &FileKey,

--- a/age-plugin/src/identity.rs
+++ b/age-plugin/src/identity.rs
@@ -161,7 +161,7 @@ pub(crate) fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
 
     // Phase 1: receive identities and stanzas
     let (identities, recipient_stanzas) = {
-        let (identities, stanzas) = conn.unidir_receive(
+        let (identities, stanzas, _) = conn.unidir_receive(
             (ADD_IDENTITY, |s| {
                 if s.args.len() == 1 && s.body.is_empty() {
                     Ok(s)
@@ -196,6 +196,7 @@ pub(crate) fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
                     })
                 }
             }),
+            (None, |_| Ok(())),
         )?;
 
         let stanzas = stanzas.and_then(|recipient_stanzas| {

--- a/age-plugin/src/identity.rs
+++ b/age-plugin/src/identity.rs
@@ -8,29 +8,10 @@ use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 use std::io;
 
+use crate::Callbacks;
+
 const ADD_IDENTITY: &str = "add-identity";
 const RECIPIENT_STANZA: &str = "recipient-stanza";
-
-/// The interface that age plugins can use to interact with an age implementation.
-pub trait Callbacks {
-    /// Shows a message to the user.
-    ///
-    /// This can be used to prompt the user to take some physical action, such as
-    /// inserting a hardware key.
-    fn message(&mut self, message: &str) -> plugin::Result<(), ()>;
-
-    /// Requests a secret value from the user, such as a passphrase.
-    ///
-    /// `message` will be displayed to the user, providing context for the request.
-    fn request_secret(&mut self, message: &str) -> plugin::Result<SecretString, ()>;
-
-    /// Sends an error.
-    ///
-    /// Note: This API may be removed in a subsequent API refactor, after we've figured
-    /// out how errors should be handled overall, and how to distinguish between hard and
-    /// soft errors.
-    fn error(&mut self, error: Error) -> plugin::Result<(), ()>;
-}
 
 /// The interface that age implementations will use to interact with an age plugin.
 pub trait IdentityPluginV1 {
@@ -66,14 +47,14 @@ pub trait IdentityPluginV1 {
     fn unwrap_file_keys(
         &mut self,
         files: Vec<Vec<Stanza>>,
-        callbacks: impl Callbacks,
+        callbacks: impl Callbacks<Error>,
     ) -> io::Result<HashMap<usize, Result<FileKey, Vec<Error>>>>;
 }
 
 /// The interface that age plugins can use to interact with an age implementation.
 struct BidirCallbacks<'a, 'b, R: io::Read, W: io::Write>(&'b mut BidirSend<'a, R, W>);
 
-impl<'a, 'b, R: io::Read, W: io::Write> Callbacks for BidirCallbacks<'a, 'b, R, W> {
+impl<'a, 'b, R: io::Read, W: io::Write> Callbacks<Error> for BidirCallbacks<'a, 'b, R, W> {
     /// Shows a message to the user.
     ///
     /// This can be used to prompt the user to take some physical action, such as

--- a/age-plugin/src/identity.rs
+++ b/age-plugin/src/identity.rs
@@ -65,6 +65,19 @@ impl<'a, 'b, R: io::Read, W: io::Write> Callbacks<Error> for BidirCallbacks<'a, 
             .map(|res| res.map(|_| ()))
     }
 
+    fn request_public(&mut self, message: &str) -> plugin::Result<String, ()> {
+        self.0
+            .send("request-public", &[], message.as_bytes())
+            .and_then(|res| match res {
+                Ok(s) => String::from_utf8(s.body)
+                    .map_err(|_| {
+                        io::Error::new(io::ErrorKind::InvalidData, "response is not UTF-8")
+                    })
+                    .map(Ok),
+                Err(()) => Ok(Err(())),
+            })
+    }
+
     /// Requests a secret value from the user, such as a passphrase.
     ///
     /// `message` will be displayed to the user, providing context for the request.

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -90,6 +90,13 @@
 //!         todo!()
 //!     }
 //!
+//!     fn add_identities<'a, I: Iterator<Item = &'a str>>(
+//!         &mut self,
+//!         identities: I,
+//!     ) -> Result<(), Vec<recipient::Error>> {
+//!         todo!()
+//!     }
+//!
 //!     fn wrap_file_key(
 //!         &mut self,
 //!         file_key: &FileKey,

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -227,6 +227,13 @@ pub trait Callbacks<E> {
     /// inserting a hardware key.
     fn message(&mut self, message: &str) -> age_core::plugin::Result<(), ()>;
 
+    /// Requests a non-secret value from the user.
+    ///
+    /// `message` will be displayed to the user, providing context for the request.
+    ///
+    /// To request secrets, use [`Callbacks::request_secret`].
+    fn request_public(&mut self, message: &str) -> age_core::plugin::Result<String, ()>;
+
     /// Requests a secret value from the user, such as a passphrase.
     ///
     /// `message` will be displayed to the user, providing context for the request.

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -97,11 +97,11 @@
 //!         todo!()
 //!     }
 //!
-//!     fn wrap_file_key(
+//!     fn wrap_file_keys(
 //!         &mut self,
-//!         file_key: &FileKey,
+//!         file_keys: Vec<FileKey>,
 //!         mut callbacks: impl Callbacks<recipient::Error>,
-//!     ) -> io::Result<Result<Vec<Stanza>, Vec<recipient::Error>>> {
+//!     ) -> io::Result<Result<Vec<Vec<Stanza>>, Vec<recipient::Error>>> {
 //!         todo!()
 //!     }
 //! }

--- a/age-plugin/src/recipient.rs
+++ b/age-plugin/src/recipient.rs
@@ -68,6 +68,19 @@ impl<'a, 'b, R: io::Read, W: io::Write> Callbacks<Error> for BidirCallbacks<'a, 
             .map(|res| res.map(|_| ()))
     }
 
+    fn request_public(&mut self, message: &str) -> plugin::Result<String, ()> {
+        self.0
+            .send("request-public", &[], message.as_bytes())
+            .and_then(|res| match res {
+                Ok(s) => String::from_utf8(s.body)
+                    .map_err(|_| {
+                        io::Error::new(io::ErrorKind::InvalidData, "response is not UTF-8")
+                    })
+                    .map(Ok),
+                Err(()) => Ok(Err(())),
+            })
+    }
+
     /// Requests a secret value from the user, such as a passphrase.
     ///
     /// `message` will be displayed to the user, providing context for the request.

--- a/age-plugin/src/recipient.rs
+++ b/age-plugin/src/recipient.rs
@@ -2,10 +2,13 @@
 
 use age_core::{
     format::{FileKey, Stanza, FILE_KEY_BYTES},
-    plugin::{Connection, UnidirSend},
+    plugin::{self, BidirSend, Connection},
 };
+use secrecy::SecretString;
 use std::convert::TryInto;
 use std::io;
+
+use crate::Callbacks;
 
 const ADD_RECIPIENT: &str = "add-recipient";
 const WRAP_FILE_KEY: &str = "wrap-file-key";
@@ -28,7 +31,47 @@ pub trait RecipientPluginV1 {
     ///
     /// Returns either one stanza per recipient, or any errors if one or more recipients
     /// could not be wrapped to.
-    fn wrap_file_key(&mut self, file_key: &FileKey) -> Result<Vec<Stanza>, Vec<Error>>;
+    ///
+    /// `callbacks` can be used to interact with the user, to have them take some physical
+    /// action or request a secret value.
+    fn wrap_file_key(
+        &mut self,
+        file_key: &FileKey,
+        callbacks: impl Callbacks<Error>,
+    ) -> io::Result<Result<Vec<Stanza>, Vec<Error>>>;
+}
+
+/// The interface that age plugins can use to interact with an age implementation.
+struct BidirCallbacks<'a, 'b, R: io::Read, W: io::Write>(&'b mut BidirSend<'a, R, W>);
+
+impl<'a, 'b, R: io::Read, W: io::Write> Callbacks<Error> for BidirCallbacks<'a, 'b, R, W> {
+    /// Shows a message to the user.
+    ///
+    /// This can be used to prompt the user to take some physical action, such as
+    /// inserting a hardware key.
+    fn message(&mut self, message: &str) -> plugin::Result<(), ()> {
+        self.0
+            .send("msg", &[], message.as_bytes())
+            .map(|res| res.map(|_| ()))
+    }
+
+    /// Requests a secret value from the user, such as a passphrase.
+    ///
+    /// `message` will be displayed to the user, providing context for the request.
+    fn request_secret(&mut self, message: &str) -> plugin::Result<SecretString, ()> {
+        self.0
+            .send("request-secret", &[], message.as_bytes())
+            .and_then(|res| match res {
+                Ok(s) => String::from_utf8(s.body)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "secret is not UTF-8"))
+                    .map(|s| Ok(SecretString::new(s))),
+                Err(()) => Ok(Err(())),
+            })
+    }
+
+    fn error(&mut self, error: Error) -> plugin::Result<(), ()> {
+        error.send(self.0).map(|()| Ok(()))
+    }
 }
 
 /// The kinds of errors that can occur within the recipient plugin state machine.
@@ -62,7 +105,7 @@ impl Error {
         }
     }
 
-    fn send<R: io::Read, W: io::Write>(self, phase: &mut UnidirSend<R, W>) -> io::Result<()> {
+    fn send<R: io::Read, W: io::Write>(self, phase: &mut BidirSend<R, W>) -> io::Result<()> {
         let index = match self {
             Error::Recipient { index, .. } => Some(index.to_string()),
             Error::Internal { .. } => None,
@@ -73,7 +116,11 @@ impl Error {
             None => vec![self.kind()],
         };
 
-        phase.send("error", &metadata, self.message().as_bytes())
+        phase
+            .send("error", &metadata, self.message().as_bytes())?
+            .unwrap();
+
+        Ok(())
     }
 }
 
@@ -122,7 +169,7 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
     };
 
     // Phase 2: wrap the file keys or return errors
-    conn.unidir_send(|mut phase| {
+    conn.bidir_send(|mut phase| {
         let (recipients, file_keys) = match (recipients, file_keys) {
             (Ok(recipients), Ok(file_keys)) => (recipients, file_keys),
             (Err(errors1), Err(errors2)) => {
@@ -148,8 +195,8 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
         } else {
             match file_keys
                 .into_iter()
-                .map(|file_key| plugin.wrap_file_key(&file_key))
-                .collect::<Result<Vec<_>, _>>()
+                .map(|file_key| plugin.wrap_file_key(&file_key, BidirCallbacks(&mut phase)))
+                .collect::<Result<Result<Vec<_>, _>, _>>()?
             {
                 Ok(files) => {
                     for (file_index, stanzas) in files.into_iter().enumerate() {
@@ -159,11 +206,9 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
                         assert_eq!(stanzas.len(), recipients.len());
 
                         for stanza in stanzas {
-                            phase.send_stanza(
-                                RECIPIENT_STANZA,
-                                &[&file_index.to_string()],
-                                &stanza,
-                            )?;
+                            phase
+                                .send_stanza(RECIPIENT_STANZA, &[&file_index.to_string()], &stanza)?
+                                .unwrap();
                         }
                     }
                 }

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -44,6 +44,8 @@ to 1.0.0 are beta releases.
 - `age::cli_common::file_io::OutputWriter::File` now wraps a `LazyFile` struct
   (instead of wrapping `std::io::File` directly), which does not open the file
   until it is first written to.
+- `age::decryptor::Callbacks` has been moved to `age::Callbacks`, as it is no
+  longer decryption-specific.
 
 ### Fixed
 - `age::cli_common::read_identities` now allows either kind of line ending in

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -35,6 +35,9 @@ to 1.0.0 are beta releases.
   `wasm32-unknown-unknown`. This feature is ignored for the `wasm32-wasi`
   target, which supports
   [`std::time::SystemTime`](https://doc.rust-lang.org/stable/std/time/struct.SystemTime.html#underlying-system-calls).
+- `age::Callbacks::request_public_string` to request non-private input from the
+  user (which will not trigger any OS-level passphrase-style prompt, unlike
+  `Callbacks::request_passphrase`).
 
 ### Changed
 - Files encrypted with this version of `age` might not decrypt with previous

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -174,6 +174,13 @@ impl Callbacks for UiCallbacks {
         eprintln!("{}", message);
     }
 
+    fn request_public_string(&self, description: &str) -> Option<String> {
+        let term = console::Term::stderr();
+        term.read_line_initial_text(description)
+            .ok()
+            .filter(|s| !s.is_empty())
+    }
+
     fn request_passphrase(&self, description: &str) -> Option<SecretString> {
         read_secret(description, &fl!("cli-passphrase-prompt"), None).ok()
     }

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use subtle::ConstantTimeEq;
 
-use crate::{fl, identity::IdentityFile, protocol::decryptor::Callbacks, Identity};
+use crate::{fl, identity::IdentityFile, Callbacks, Identity};
 
 #[cfg(feature = "plugin")]
 use crate::plugin;

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -239,6 +239,11 @@ pub trait Callbacks {
     /// inserting a hardware key.
     fn prompt(&self, message: &str);
 
+    /// Requests non-private input from the user.
+    ///
+    /// To request private inputs, use [`Callbacks::request_passphrase`].
+    fn request_public_string(&self, description: &str) -> Option<String>;
+
     /// Requests a passphrase to decrypt a key.
     fn request_passphrase(&self, description: &str) -> Option<SecretString>;
 }

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -173,6 +173,7 @@ pub mod plugin;
 pub mod ssh;
 
 use age_core::format::{FileKey, Stanza};
+use secrecy::SecretString;
 
 /// A private key or other value that can unwrap an opaque file key from a recipient
 /// stanza.
@@ -225,6 +226,21 @@ pub trait Recipient {
     ///
     /// [one joint]: https://www.imperialviolet.org/2016/05/16/agility.html
     fn wrap_file_key(&self, file_key: &FileKey) -> Result<Vec<Stanza>, EncryptError>;
+}
+
+/// Callbacks that might be triggered during encryption or decryption.
+///
+/// Structs that implement this trait should be given directly to the individual
+/// `Recipient` or `Identity` implementations that require them.
+pub trait Callbacks {
+    /// Shows a message to the user.
+    ///
+    /// This can be used to prompt the user to take some physical action, such as
+    /// inserting a hardware key.
+    fn prompt(&self, message: &str);
+
+    /// Requests a passphrase to decrypt a key.
+    fn request_passphrase(&self, description: &str) -> Option<SecretString>;
 }
 
 /// Helper for fuzzing the Header parser and serializer.

--- a/age/src/plugin.rs
+++ b/age/src/plugin.rs
@@ -157,19 +157,24 @@ impl Plugin {
 ///
 /// This struct implements [`Recipient`], enabling the plugin to encrypt a file to the
 /// entire set of recipients.
-pub struct RecipientPluginV1 {
+pub struct RecipientPluginV1<C: Callbacks> {
     plugin: Plugin,
     recipients: Vec<Recipient>,
+    callbacks: C,
 }
 
-impl RecipientPluginV1 {
+impl<C: Callbacks> RecipientPluginV1<C> {
     /// Creates an age plugin from a plugin name and a list of recipients.
     ///
     /// The list of recipients will be filtered by the plugin name; recipients that don't
     /// match will be ignored.
     ///
     /// Returns an error if the plugin's binary cannot be found in `$PATH`.
-    pub fn new(plugin_name: &str, recipients: &[Recipient]) -> Result<Self, EncryptError> {
+    pub fn new(
+        plugin_name: &str,
+        recipients: &[Recipient],
+        callbacks: C,
+    ) -> Result<Self, EncryptError> {
         Plugin::new(plugin_name)
             .map_err(|binary_name| EncryptError::MissingPlugin { binary_name })
             .map(|plugin| RecipientPluginV1 {
@@ -179,11 +184,12 @@ impl RecipientPluginV1 {
                     .filter(|r| r.name == plugin_name)
                     .cloned()
                     .collect(),
+                callbacks,
             })
     }
 }
 
-impl crate::Recipient for RecipientPluginV1 {
+impl<C: Callbacks> crate::Recipient for RecipientPluginV1<C> {
     fn wrap_file_key(&self, file_key: &FileKey) -> Result<Vec<Stanza>, EncryptError> {
         // Open connection
         let mut conn = self.plugin.connect(RECIPIENT_V1)?;
@@ -197,53 +203,73 @@ impl crate::Recipient for RecipientPluginV1 {
         })?;
 
         // Phase 2: collect either stanzas or errors
-        let (stanzas, mut errors) = {
-            let (stanzas, errors) = conn.unidir_receive(
-                (CMD_RECIPIENT_STANZA, |mut s| {
-                    if s.args.len() >= 2 {
+        let mut stanzas = vec![];
+        let mut errors = vec![];
+        if let Err(e) = conn.bidir_receive(
+            &[CMD_MSG, CMD_REQUEST_SECRET, CMD_RECIPIENT_STANZA, CMD_ERROR],
+            |mut command, reply| match command.tag.as_str() {
+                CMD_MSG => {
+                    self.callbacks
+                        .prompt(&String::from_utf8_lossy(&command.body));
+                    reply.ok(None)
+                }
+                CMD_REQUEST_SECRET => {
+                    if let Some(secret) = self
+                        .callbacks
+                        .request_passphrase(&String::from_utf8_lossy(&command.body))
+                    {
+                        reply.ok(Some(secret.expose_secret().as_bytes()))
+                    } else {
+                        reply.fail()
+                    }
+                }
+                CMD_RECIPIENT_STANZA => {
+                    if command.args.len() >= 2 {
                         // We only requested one file key be wrapped.
-                        if s.args.remove(0) == "0" {
-                            s.tag = s.args.remove(0);
-                            Ok(s)
+                        if command.args.remove(0) == "0" {
+                            command.tag = command.args.remove(0);
+                            stanzas.push(command);
                         } else {
-                            Err(PluginError::Other {
+                            errors.push(PluginError::Other {
                                 kind: "internal".to_owned(),
                                 metadata: vec![],
                                 message: "plugin wrapped file key to a file we didn't provide"
                                     .to_owned(),
-                            })
+                            });
                         }
                     } else {
-                        Err(PluginError::Other {
+                        errors.push(PluginError::Other {
                             kind: "internal".to_owned(),
                             metadata: vec![],
                             message: format!(
                                 "{} command must have at least two metadata arguments",
                                 CMD_RECIPIENT_STANZA
                             ),
-                        })
+                        });
                     }
-                }),
-                (CMD_ERROR, |s| {
-                    // Here, errors are are okay!
-                    if s.args.len() == 2 && s.args[0] == "recipient" {
-                        let index: usize = s.args[1].parse().unwrap();
-                        Ok(PluginError::Recipient {
+                    reply.ok(None)
+                }
+                CMD_ERROR => {
+                    if command.args.len() == 2 && command.args[0] == "recipient" {
+                        let index: usize = command.args[1].parse().unwrap();
+                        errors.push(PluginError::Recipient {
                             binary_name: binary_name(&self.recipients[index].name),
                             recipient: self.recipients[index].recipient.clone(),
-                            message: String::from_utf8_lossy(&s.body).to_string(),
-                        })
+                            message: String::from_utf8_lossy(&command.body).to_string(),
+                        });
                     } else {
-                        Ok(PluginError::from(s))
+                        errors.push(PluginError::from(command));
                     }
-                }),
-            )?;
-            (stanzas, errors.expect("All Ok"))
+                    reply.ok(None)
+                }
+                _ => unreachable!(),
+            },
+        ) {
+            return Err(e.into());
         };
-        match (stanzas, errors.is_empty()) {
-            (Ok(stanzas), true) if !stanzas.is_empty() => Ok(stanzas),
-            (Ok(stanzas), b) => {
-                let a = stanzas.is_empty();
+        match (stanzas.is_empty(), errors.is_empty()) {
+            (false, true) => Ok(stanzas),
+            (a, b) => {
                 if a & b {
                     errors.push(PluginError::Other {
                         kind: "internal".to_owned(),
@@ -259,9 +285,6 @@ impl crate::Recipient for RecipientPluginV1 {
                 }
                 Err(EncryptError::Plugin(errors))
             }
-            (Err(errs), _) => Err(EncryptError::Plugin(
-                errors.into_iter().chain(errs.into_iter()).collect(),
-            )),
         }
     }
 }

--- a/age/src/plugin.rs
+++ b/age/src/plugin.rs
@@ -14,8 +14,8 @@ use std::process::{ChildStdin, ChildStdout};
 
 use crate::{
     error::{DecryptError, EncryptError, PluginError},
-    protocol::decryptor::Callbacks,
     util::parse_bech32,
+    Callbacks,
 };
 
 // Plugin HRPs are age1[name] and AGE-PLUGIN-[NAME]-

--- a/age/src/protocol/decryptor.rs
+++ b/age/src/protocol/decryptor.rs
@@ -149,15 +149,3 @@ impl<R: AsyncRead + Unpin> PassphraseDecryptor<R> {
             .map(|payload_key| Stream::decrypt_async(payload_key, self.0.input))
     }
 }
-
-/// Callbacks that might be triggered during decryption.
-pub trait Callbacks {
-    /// Shows a message to the user.
-    ///
-    /// This can be used to prompt the user to take some physical action, such as
-    /// inserting a hardware key.
-    fn prompt(&self, message: &str);
-
-    /// Requests a passphrase to decrypt a key.
-    fn request_passphrase(&self, description: &str) -> Option<SecretString>;
-}

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -27,8 +27,8 @@ use super::{
 };
 use crate::{
     error::DecryptError,
-    protocol::decryptor::Callbacks,
     util::read::{base64_arg, wrapped_str_while_encoded},
+    Callbacks,
 };
 
 /// An SSH private key for decrypting an age file.

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -2,7 +2,9 @@
 
 use age::{
     armor::{ArmoredReader, ArmoredWriter, Format},
-    cli_common::{file_io, read_identities, read_or_generate_passphrase, read_secret, Passphrase},
+    cli_common::{
+        file_io, read_identities, read_or_generate_passphrase, read_secret, Passphrase, UiCallbacks,
+    },
     plugin, Recipient,
 };
 use gumdrop::{Options, ParsingStyle};
@@ -123,6 +125,7 @@ fn read_recipients(
         recipients.push(Box::new(plugin::RecipientPluginV1::new(
             plugin_name,
             &plugin_recipients,
+            UiCallbacks,
         )?))
     }
 

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -125,6 +125,7 @@ fn read_recipients(
         recipients.push(Box::new(plugin::RecipientPluginV1::new(
             plugin_name,
             &plugin_recipients,
+            &[],
             UiCallbacks,
         )?))
     }


### PR DESCRIPTION
This brings in the last changes to the plugin specification:

- Phase 2 of the `recipient-v1` state machine is now bi-directional, enabling plugins to interact with users during encryption.
- Plugins may receive identities as well as recipients during the `recipient-v1` state machine.
- Plugins can now request non-secret strings from users, in addition to secret strings like passphrases. User input will not be hidden int the UI when requesting non-secret strings.