### PR TITLE
rage: Prevent INPUT and OUTPUT from being set to the same path

### DIFF
--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -75,6 +75,7 @@ prompt-passphrase = Passphrase
 err-failed-to-open-output = Failed to open output: {$err}
 err-failed-to-write-output = Failed to write to output: {$err}
 err-passphrase-timed-out = Timed out waiting for passphrase input.
+err-same-input-and-output = Input and output are the same file '{$filename}'.
 
 err-ux-A = Did {-rage} not do what you expected? Could an error be more useful?
 err-ux-B = Tell us

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -192,6 +192,7 @@ impl fmt::Display for DecryptError {
 pub(crate) enum Error {
     Decryption(DecryptError),
     Encryption(EncryptError),
+    SameInputAndOutput(String),
 }
 
 impl From<DecryptError> for Error {
@@ -213,6 +214,15 @@ impl fmt::Debug for Error {
         match self {
             Error::Decryption(e) => writeln!(f, "{}", e)?,
             Error::Encryption(e) => writeln!(f, "{}", e)?,
+            Error::SameInputAndOutput(filename) => writeln!(
+                f,
+                "{}",
+                fl!(
+                    crate::LANGUAGE_LOADER,
+                    "err-same-input-and-output",
+                    filename = filename.as_str()
+                )
+            )?,
         }
         writeln!(f)?;
         writeln!(f, "[ {} ]", crate::fl!("err-ux-A"))?;


### PR DESCRIPTION
Now that we are going to overwrite OUTPUT instead of halting with "file exists", we do not want it to be set to INPUT!