### PR TITLE
rage: Allow encrypting to identity files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The reference interoperable Golang implementation is available at
 
 ```
 Usage:
-  rage -r RECIPIENT [-a] [-o OUTPUT] [INPUT]
+  rage [--encrypt] -r RECIPIENT [-i IDENTITY] [-a] [-o OUTPUT] [INPUT]
   rage --decrypt [-i IDENTITY] [-o OUTPUT] [INPUT]
 
 Positional arguments:
@@ -27,13 +27,14 @@ Positional arguments:
 Optional arguments:
   -h, --help                  Print this help message and exit.
   -V, --version               Print version info and exit.
+  -e, --encrypt               Encrypt the input (the default).
   -d, --decrypt               Decrypt the input.
   -p, --passphrase            Encrypt with a passphrase instead of recipients.
   --max-work-factor WF        Maximum work factor to allow for passphrase decryption.
   -a, --armor                 Encrypt to a PEM encoded format.
   -r, --recipient RECIPIENT   Encrypt to the specified RECIPIENT. May be repeated.
   -R, --recipients-file PATH  Encrypt to the recipients listed at PATH. May be repeated.
-  -i, --identity IDENTITY     Use the private key file at IDENTITY. May be repeated.
+  -i, --identity IDENTITY     Use the identity file at IDENTITY. May be repeated.
   -o, --output OUTPUT         Write the result to the file at path OUTPUT.
 
 INPUT defaults to standard input, and OUTPUT defaults to standard output.

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -16,6 +16,8 @@ to 1.0.0 are beta releases.
   - See https://hackmd.io/@str4d/age-plugin-spec for the beta specification.
 - The `-R/--recipients-file` flag, which accepts a path to a file containing age
   recipients, one per line (ignoring "#" prefixed comments and empty lines).
+- The `-e/--encrypt` flag, to allow encryption to be an explicit choice (instead
+  of relying on `-d/--decrypt` not being present).
 
 ### Changed
 - Files encrypted with this version of `rage` might not decrypt with previous
@@ -24,6 +26,9 @@ to 1.0.0 are beta releases.
   change is added, which has a 3% chance per file).
 - `-r/--recipient` now has the specific type "recipient" which better reflects
   its name, rather than the ambiguous "source of recipients" it was previously.
+- `-i/--identity` can now be used when encrypting files. This requires the
+  `-e/--encrypt` flag (to prevent ambiguity, e.g. if the user wants to decrypt
+  but forgets the `-d/--decrypt` flag).
 
 ### Removed
 - Recipients file support from `-r/--recipient` (use `-R/--recipients-file`

--- a/rage/examples/generate-completions.rs
+++ b/rage/examples/generate-completions.rs
@@ -29,6 +29,7 @@ fn generate_completions(mut app: App, bin_name: &str) {
 fn rage_completions() {
     let app = App::new("rage")
         .arg(Arg::new("input"))
+        .arg(Arg::new("encrypt").short('e').long("encrypt"))
         .arg(Arg::new("decrypt").short('d').long("decrypt"))
         .arg(Arg::new("passphrase").short('p').long("passphrase"))
         .arg(

--- a/rage/examples/generate-docs.rs
+++ b/rage/examples/generate-docs.rs
@@ -32,6 +32,12 @@ fn rage_page() {
         )
         .flag(
             Flag::new()
+                .short("-e")
+                .long("--encrypt")
+                .help("Encrypt the input. By default, the input is encrypted."),
+        )
+        .flag(
+            Flag::new()
                 .short("-d")
                 .long("--decrypt")
                 .help("Decrypt the input. By default, the input is encrypted."),
@@ -64,7 +70,7 @@ fn rage_page() {
             Opt::new("IDENTITY")
                 .short("-i")
                 .long("--identity")
-                .help("Use the private key file at IDENTITY. May be repeated."),
+                .help("Use the identity file at IDENTITY. May be repeated."),
         )
         .option(
             Opt::new("OUTPUT")
@@ -99,6 +105,11 @@ fn rage_page() {
             Example::new()
                 .text("Encryption to a list of recipients in a file")
                 .command("tar cv ~/xxx | rage -R recipients.txt > xxx.tar.age"),
+        )
+        .example(
+            Example::new()
+                .text("Encryption to several identities")
+                .command("tar cv ~/xxx | rage -e -i keyA.txt -i keyB.txt > xxx.tar.age"),
         )
         .example(
             Example::new()

--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -15,6 +15,7 @@
 
 -flag-armor = -a/--armor
 -flag-decrypt = -d/--decrypt
+-flag-encrypt = -e/--encrypt
 -flag-identity = -i/--identity
 -flag-recipient = -r/--recipient
 -flag-recipients-file = -R/--recipients-file
@@ -74,6 +75,8 @@ prompt-passphrase = Passphrase
 
 err-failed-to-open-output = Failed to open output: {$err}
 err-failed-to-write-output = Failed to write to output: {$err}
+err-identity-ambiguous = {-flag-identity} requires either {-flag-encrypt} or {-flag-decrypt}.
+err-mixed-encrypt-decrypt = {-flag-encrypt} can't be used with {-flag-decrypt}.
 err-passphrase-timed-out = Timed out waiting for passphrase input.
 err-same-input-and-output = Input and output are the same file '{$filename}'.
 
@@ -89,14 +92,12 @@ rec-enc-broken-stdout = Are you piping to a program that isn't reading from stdi
 
 err-enc-broken-file = Could not write to file: {$err}
 
-err-enc-identity = {-flag-identity} can't be used in encryption mode.
-rec-enc-identity = Did you forget to specify {-flag-decrypt}?
-
 err-enc-invalid-recipient = Invalid recipient '{$recipient}'
 
 err-enc-missing-recipients = Missing recipients.
 rec-enc-missing-recipients = Did you forget to specify {-flag-recipient}?
 
+err-enc-mixed-identity-passphrase = {-flag-identity} can't be used with {-flag-passphrase}.
 err-enc-mixed-recipient-passphrase = {-flag-recipient} can't be used with {-flag-passphrase}
 err-enc-mixed-recipients-file-passphrase = {-flag-recipients-file} can't be used with {-flag-passphrase}
 err-enc-passphrase-without-file = File to encrypt must be passed as an argument when using {-flag-passphrase}

--- a/rage/i18n/es-AR/rage.ftl
+++ b/rage/i18n/es-AR/rage.ftl
@@ -15,6 +15,7 @@
 
 -flag-armor = -a/--armor
 -flag-decrypt = -d/--decrypt
+-flag-encrypt = -e/--encrypt
 -flag-identity = -i/--identity
 -flag-recipient = -r/--recipient
 -flag-recipients-file = -R/--recipients-file
@@ -75,6 +76,7 @@ prompt-passphrase = Frase contraseña
 
 err-failed-to-open-output = Fallo al abrir output: {$err}
 err-failed-to-write-output = Fallo al escribir al output: {$err}
+err-mixed-encrypt-decrypt = {-flag-encrypt} no puede ser usado con {-flag-decrypt}.
 err-passphrase-timed-out = Tiempo de espera para ingresar frase contraseña agotado.
 
 err-ux-A = Acaso {-rage} no hizo lo que esperabas? Puede que un error te sea mas útil?
@@ -89,14 +91,12 @@ rec-enc-broken-stdout = Estás enviando por pipe a un programa que no está leye
 
 err-enc-broken-file = No se pudo escribir al archivo: {$err}
 
-err-enc-identity = {-flag-identity} no puede ser utilizado en modo encripción.
-rec-enc-identity = ¿Te olvidaste de especificar {-flag-decrypt}?
-
 err-enc-invalid-recipient = Destinatario inválido '{$recipient}'
 
 err-enc-missing-recipients = No se encontraron destinatarios.
 rec-enc-missing-recipients = ¿Te olvidaste de especificar {-flag-recipient}?
 
+err-enc-mixed-identity-passphrase = {-flag-identity} no puede ser usado con {-flag-passphrase}.
 err-enc-mixed-recipient-passphrase = {-flag-recipient} no puede ser usado con {-flag-passphrase}
 err-enc-mixed-recipients-file-passphrase = {-flag-recipients-file} no puede ser usado con {-flag-passphrase}
 err-enc-passphrase-without-file = El archivo a encriptar debe ser pasado como argumento cuando se utiliza {-flag-passphrase}

--- a/rage/i18n/it-IT/rage.ftl
+++ b/rage/i18n/it-IT/rage.ftl
@@ -15,6 +15,7 @@
 
 -flag-armor = -a/--armor
 -flag-decrypt = -d/--decrypt
+-flag-encrypt = -e/--encrypt
 -flag-identity = -i/--identity
 -flag-recipient = -r/--recipient
 -flag-recipients-file = -R/--recipients-file
@@ -76,6 +77,7 @@ prompt-passphrase = Passphrase
 
 err-failed-to-open-output = Impossibile aprire l'output: {$err}
 err-failed-to-write-output = Impossibile scrivere sull'output: {$err}
+err-enc-mixed-encrypt-decrypt = {-flag-encrypt} non può essere usato assieme a {-flag-decrypt}.
 err-passphrase-timed-out = Tempo di attesa per l'inserimento della passphrase scaduto.
 
 err-ux-A = {-rage} non fa quello che ti aspetti? Potrebbe un errore essere più utile?
@@ -90,14 +92,12 @@ rec-enc-broken-stdout = Stai usando una pipe verso un programma che non sta legg
 
 err-enc-broken-file = Impossibile scrivere sul file: {$err}
 
-err-enc-identity = {-flag-identity} non può essere usato in modalità cifrazione.
-rec-enc-identity = Hai dimenticato di specificare {-flag-decrypt}?
-
 err-enc-invalid-recipient = Destinatario '{$recipient}' invalido
 
 err-enc-missing-recipients = Destinatari mancanti.
 rec-enc-missing-recipients = Hai dimenticato di specificare {-flag-recipient}?
 
+err-enc-mixed-identity-passphrase = {-flag-identity} non può essere usato assieme a {-flag-passphrase}.
 err-enc-mixed-recipient-passphrase = {-flag-recipient} non può essere usato assieme a {-flag-passphrase}
 err-enc-mixed-recipients-file-passphrase = {-flag-recipients-file} non può essere usato assieme a {-flag-passphrase}
 err-enc-passphrase-without-file = Il file da cifrare deve essere passato come argomento quando si usa {-flag-passphrase}

--- a/rage/i18n/zh-CN/rage.ftl
+++ b/rage/i18n/zh-CN/rage.ftl
@@ -15,6 +15,7 @@
 
 -flag-armor = -a/--armor
 -flag-decrypt = -d/--decrypt
+-flag-encrypt = -e/--encrypt
 -flag-identity = -i/--identity
 -flag-recipient = -r/--recipient
 -flag-recipients-file = -R/--recipients-file
@@ -73,6 +74,7 @@ prompt-passphrase = 密码短语
 
 err-failed-to-open-output = 未能打开出输： {$err}
 err-failed-to-write-output = 未能写入出输： {$err}
+err-enc-mixed-encrypt-decrypt = {-flag-encrypt} 和 {-flag-decrypt} 标记不可联用。
 err-passphrase-timed-out = 等待输入密码短语时超时了。
 
 err-ux-A = {-rage} 的行为与您的预期不符吗? 或是某个错误消息可包含更多信息?
@@ -87,14 +89,12 @@ rec-enc-broken-stdout = 您是否输出至非从 stdin 读取数据的程序？
 
 err-enc-broken-file = 未能写入文件： {$err}
 
-err-enc-identity = {-flag-identity} 不可在加密模式使用。
-rec-enc-identity = 您是否忘记指定 {-flag-decrypt} 标记？
-
 err-enc-invalid-recipient = 无效接收方 '{$recipient}'
 
 err-enc-missing-recipients = 缺少接收方。
 rec-enc-missing-recipients = 您是否忘记指定 {-flag-recipient} 标记？
 
+err-enc-mixed-identity-passphrase = {-flag-identity} 和 {-flag-passphrase} 标记不可联用。
 err-enc-mixed-recipient-passphrase = {-flag-recipient} 和 {-flag-passphrase} 标记不可联用。
 err-enc-mixed-recipients-file-passphrase = {-flag-recipients-file} 和 {-flag-passphrase} 标记不可联用。
 err-enc-passphrase-without-file = 在使用 {-flag-passphrase} 时， 必将要加密的文件传递为参数

--- a/rage/i18n/zh-TW/rage.ftl
+++ b/rage/i18n/zh-TW/rage.ftl
@@ -15,6 +15,7 @@
 
 -flag-armor = -a/--armor
 -flag-decrypt = -d/--decrypt
+-flag-encrypt = -e/--encrypt
 -flag-identity = -i/--identity
 -flag-recipient = -r/--recipient
 -flag-recipients-file = -R/--recipients-file
@@ -73,6 +74,7 @@ prompt-passphrase = 密碼短語
 
 err-failed-to-open-output = 未能打開出輸： {$err}
 err-failed-to-write-output = 未能寫入出輸： {$err}
+err-enc-mixed-encrypt-decrypt = {-flag-encrypt} 和 {-flag-decrypt} 標記不可聯用。
 err-passphrase-timed-out = 等待輸入密碼短語時超時了。
 
 err-ux-A = {-rage} 的行為與您的預期不符嗎? 或是某個錯誤消息可包含更多信息?
@@ -87,14 +89,12 @@ rec-enc-broken-stdout = 您是否輸出至非從 stdin 讀取數據的程序？
 
 err-enc-broken-file = 未能寫入文件： {$err}
 
-err-enc-identity = {-flag-identity} 不可在加密模式使用。
-rec-enc-identity = 您是否忘記指定 {-flag-decrypt} 標記？
-
 err-enc-invalid-recipient = 無效接收方 '{$recipient}'
 
 err-enc-missing-recipients = 缺少接收方。
 rec-enc-missing-recipients = 您是否忘記指定 {-flag-recipient} 標記？
 
+err-enc-mixed-identity-passphrase = {-flag-identity} 和 {-flag-passphrase} 標記不可聯用。
 err-enc-mixed-recipient-passphrase = {-flag-recipient} 和 {-flag-passphrase} 標記不可聯用。
 err-enc-mixed-recipients-file-passphrase = {-flag-recipients-file} 和 {-flag-passphrase} 標記不可聯用。
 err-enc-passphrase-without-file = 在使用 {-flag-passphrase} 時， 必將要加密的文件傳遞為參數


### PR DESCRIPTION
This is specifically intended to support plugins that use symmetric identities, where both encryption and decryption require a secret. We don't want recipient strings (`age1name1...`) to contain secret values, as this is easily overlooked by users. Instead, symmetric plugins would only provide an identity file, and users would provide it during both encryption and decryption.

As a side-effect, we now also support using identity files for native age recipients and asymmetric plugins, as well as SSH keys; this keeps the UX consistent.

To prevent ambiguity (e.g. if the user wants to decrypt but forgets the `-d/--decrypt` flag), we add an `-e/--encrypt` flag and require it when encrypting to identity files.