### PR TITLE
age: Enable all features and doc_cfg for docs.rs

### DIFF
--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -121,3 +121,7 @@ required-features = ["ssh"]
 [[bench]]
 name = "throughput"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]


### PR DESCRIPTION
This instructs docs.rs to render the feature-flagged parts of the library
in the documentation.

Fixes str4d/rage#209.