### PR TITLE
rage: Use explicit syntax for indentation whitespace

### DIFF
--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -35,8 +35,8 @@ usage-header = Usage:
 
 rage-usage =
     {usage-header}
-      {$usage_a}
-      {$usage_b}
+    {"  "}{$usage_a}
+    {"  "}{$usage_b}
 
     {$flags}
 

--- a/rage/i18n/es-AR/rage.ftl
+++ b/rage/i18n/es-AR/rage.ftl
@@ -35,8 +35,8 @@ usage-header = Usage:
 
 rage-usage =
     {usage-header}
-      {$usage_a}
-      {$usage_b}
+    {"  "}{$usage_a}
+    {"  "}{$usage_b}
 
     {$flags}
 

--- a/rage/i18n/it-IT/rage.ftl
+++ b/rage/i18n/it-IT/rage.ftl
@@ -35,8 +35,8 @@ usage-header = Usage:
 
 rage-usage =
     {usage-header}
-      {$usage_a}
-      {$usage_b}
+    {"  "}{$usage_a}
+    {"  "}{$usage_b}
 
     {$flags}
 

--- a/rage/i18n/zh-CN/rage.ftl
+++ b/rage/i18n/zh-CN/rage.ftl
@@ -35,8 +35,8 @@ usage-header = Usage:
 
 rage-usage =
     {usage-header}
-      {$usage_a}
-      {$usage_b}
+    {"  "}{$usage_a}
+    {"  "}{$usage_b}
 
     {$flags}
 

--- a/rage/i18n/zh-TW/rage.ftl
+++ b/rage/i18n/zh-TW/rage.ftl
@@ -35,8 +35,8 @@ usage-header = Usage:
 
 rage-usage =
     {usage-header}
-      {$usage_a}
-      {$usage_b}
+    {"  "}{$usage_a}
+    {"  "}{$usage_b}
 
     {$flags}
 

--- a/rage/src/bin/rage-keygen/main.rs
+++ b/rage/src/bin/rage-keygen/main.rs
@@ -50,6 +50,9 @@ fn main() {
     let requested_languages = DesktopLanguageRequester::requested_languages();
     i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();
     age::localizer().select(&requested_languages).unwrap();
+    // Unfortunately the common Windows terminals don't support Unicode Directionality
+    // Isolation Marks, so we disable them for now.
+    LANGUAGE_LOADER.set_use_isolating(false);
 
     let opts = AgeOptions::parse_args_default_or_exit();
 

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -200,6 +200,9 @@ fn main() -> Result<(), Error> {
     let requested_languages = DesktopLanguageRequester::requested_languages();
     i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();
     age::localizer().select(&requested_languages).unwrap();
+    // Unfortunately the common Windows terminals don't support Unicode Directionality
+    // Isolation Marks, so we disable them for now.
+    LANGUAGE_LOADER.set_use_isolating(false);
 
     let args = args().collect::<Vec<_>>();
 

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -403,6 +403,9 @@ fn main() -> Result<(), error::Error> {
     let requested_languages = DesktopLanguageRequester::requested_languages();
     i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();
     age::localizer().select(&requested_languages).unwrap();
+    // Unfortunately the common Windows terminals don't support Unicode Directionality
+    // Isolation Marks, so we disable them for now.
+    LANGUAGE_LOADER.set_use_isolating(false);
 
     let args = args().collect::<Vec<_>>();
 


### PR DESCRIPTION
`i18n-embed-fl` doesn't correctly handle indentation whitespace preceding a variable. By using explicit string syntax for whitespace, we avoid this issue by not having any implicit indentations.