### PR TITLE
rage-mount-dir: OverlayFS that transparently decrypts age-encrypted files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "man",
+ "nix",
  "pinentry",
  "rust-embed",
  "secrecy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,6 +1802,7 @@ name = "rage"
 version = "0.6.0"
 dependencies = [
  "age",
+ "age-core",
  "chrono",
  "clap 3.0.0-beta.2",
  "clap_generate",

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -66,7 +66,7 @@ impl<'a> AgeStanza<'a> {
 /// recipient.
 ///
 /// This is the owned type; see [`AgeStanza`] for the reference type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Stanza {
     /// A tag identifying this stanza type.
     pub tag: String,

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -25,14 +25,14 @@ pub fn read_identities<E, G, H>(
     file_not_found: G,
     identity_encrypted_without_passphrase: H,
     #[cfg(feature = "ssh")] unsupported_ssh: impl Fn(String, crate::ssh::UnsupportedKey) -> E,
-) -> Result<Vec<Box<dyn Identity>>, E>
+) -> Result<Vec<Box<dyn Identity + Send + Sync>>, E>
 where
     E: From<crate::DecryptError>,
     E: From<io::Error>,
     G: Fn(String) -> E,
     H: Fn(String) -> E,
 {
-    let mut identities: Vec<Box<dyn Identity>> = vec![];
+    let mut identities: Vec<Box<dyn Identity + Send + Sync>> = vec![];
 
     for filename in filenames {
         // Try parsing as an encrypted age identity.

--- a/age/src/identity.rs
+++ b/age/src/identity.rs
@@ -19,8 +19,8 @@ pub enum IdentityFileEntry {
 impl IdentityFileEntry {
     pub(crate) fn into_identity(
         self,
-        callbacks: impl Callbacks + 'static,
-    ) -> Result<Box<dyn crate::Identity>, DecryptError> {
+        callbacks: impl Callbacks + Send + Sync + 'static,
+    ) -> Result<Box<dyn crate::Identity + Send + Sync>, DecryptError> {
         match self {
             IdentityFileEntry::Native(i) => Ok(Box::new(i)),
             #[cfg(feature = "plugin")]

--- a/rage/Cargo.toml
+++ b/rage/Cargo.toml
@@ -59,6 +59,7 @@ secrecy = "0.8"
 # rage-mount dependencies
 fuse_mt = { version = "0.5.1", optional = true }
 libc = { version = "0.2", optional = true }
+nix = { version = "0.20", optional = true }
 tar = { version = "0.4", optional = true }
 time = { version = "0.1", optional = true }
 zip = { version = "0.5.9", optional = true }
@@ -71,7 +72,7 @@ man = "0.3"
 
 [features]
 default = ["ssh"]
-mount = ["fuse_mt", "libc", "tar", "time", "zip"]
+mount = ["fuse_mt", "libc", "nix", "tar", "time", "zip"]
 ssh = ["age/ssh"]
 unstable = ["age/unstable"]
 
@@ -85,5 +86,10 @@ bench = false
 
 [[bin]]
 name = "rage-mount"
+required-features = ["mount"]
+bench = false
+
+[[bin]]
+name = "rage-mount-dir"
 required-features = ["mount"]
 bench = false

--- a/rage/Cargo.toml
+++ b/rage/Cargo.toml
@@ -57,6 +57,7 @@ rust-embed = "5"
 secrecy = "0.8"
 
 # rage-mount dependencies
+age-core = { version = "0.6.0", path = "../age-core", optional = true }
 fuse_mt = { version = "0.5.1", optional = true }
 libc = { version = "0.2", optional = true }
 nix = { version = "0.20", optional = true }
@@ -72,7 +73,7 @@ man = "0.3"
 
 [features]
 default = ["ssh"]
-mount = ["fuse_mt", "libc", "nix", "tar", "time", "zip"]
+mount = ["age-core", "fuse_mt", "libc", "nix", "tar", "time", "zip"]
 ssh = ["age/ssh"]
 unstable = ["age/unstable"]
 

--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -142,9 +142,12 @@ rec-dec-recipient-flag = Did you mean to use {-flag-identity} to specify a priva
 info-decrypting = Decrypting {$filename}
 info-mounting-as-fuse = Mounting as FUSE filesystem
 
+err-mnt-missing-source = Missing source.
 err-mnt-missing-filename = Missing filename.
 err-mnt-missing-mountpoint = Missing mountpoint.
 err-mnt-missing-types = Missing {-flag-mnt-types}.
+err-mnt-must-be-dir = Mountpoint must be a directory.
+err-mnt-source-must-be-dir = Source must be a directory.
 err-mnt-unknown-type = Unknown filesystem type "{$fs_type}"
 
 ## Unstable features

--- a/rage/src/bin/rage-mount-dir/main.rs
+++ b/rage/src/bin/rage-mount-dir/main.rs
@@ -1,0 +1,193 @@
+use fuse_mt::FilesystemMT;
+use gumdrop::Options;
+use i18n_embed::{
+    fluent::{fluent_language_loader, FluentLanguageLoader},
+    DesktopLanguageRequester,
+};
+use lazy_static::lazy_static;
+use log::{error, info};
+use rust_embed::RustEmbed;
+use std::ffi::OsStr;
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+
+mod overlay;
+mod util;
+
+#[derive(RustEmbed)]
+#[folder = "i18n"]
+struct Translations;
+
+const TRANSLATIONS: Translations = Translations {};
+
+lazy_static! {
+    static ref LANGUAGE_LOADER: FluentLanguageLoader = fluent_language_loader!();
+}
+
+macro_rules! fl {
+    ($message_id:literal) => {{
+        i18n_embed_fl::fl!(LANGUAGE_LOADER, $message_id)
+    }};
+}
+
+macro_rules! wfl {
+    ($f:ident, $message_id:literal) => {
+        write!($f, "{}", fl!($message_id))
+    };
+}
+
+enum Error {
+    Age(age::DecryptError),
+    Io(io::Error),
+    MissingMountpoint,
+    MissingSource,
+    MountpointMustBeDir,
+    Nix(nix::Error),
+    SourceMustBeDir,
+}
+
+impl From<age::DecryptError> for Error {
+    fn from(e: age::DecryptError) -> Self {
+        Error::Age(e)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<nix::Error> for Error {
+    fn from(e: nix::Error) -> Self {
+        Error::Nix(e)
+    }
+}
+
+// Rust only supports `fn main() -> Result<(), E: Debug>`, so we implement `Debug`
+// manually to provide the error output we want.
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Age(e) => match e {
+                age::DecryptError::ExcessiveWork { required, .. } => {
+                    writeln!(f, "{}", e)?;
+                    write!(
+                        f,
+                        "{}",
+                        i18n_embed_fl::fl!(
+                            LANGUAGE_LOADER,
+                            "rec-dec-excessive-work",
+                            wf = required
+                        )
+                    )
+                }
+                _ => write!(f, "{}", e),
+            },
+            Error::Io(e) => write!(f, "{}", e),
+            Error::MissingMountpoint => wfl!(f, "err-mnt-missing-mountpoint"),
+            Error::MissingSource => wfl!(f, "err-mnt-missing-source"),
+            Error::MountpointMustBeDir => wfl!(f, "err-mnt-must-be-dir"),
+            Error::Nix(e) => write!(f, "{}", e),
+            Error::SourceMustBeDir => wfl!(f, "err-mnt-source-must-be-dir"),
+        }?;
+        writeln!(f)?;
+        writeln!(f, "[ {} ]", fl!("err-ux-A"))?;
+        write!(
+            f,
+            "[ {}: https://str4d.xyz/rage/report {} ]",
+            fl!("err-ux-B"),
+            fl!("err-ux-C")
+        )
+    }
+}
+
+#[derive(Debug, Options)]
+struct AgeMountOptions {
+    #[options(free, help = "The directory to mount.")]
+    directory: String,
+
+    #[options(free, help = "The path to mount at.")]
+    mountpoint: String,
+
+    #[options(help = "Print this help message and exit.")]
+    help: bool,
+
+    #[options(help = "Print version info and exit.", short = "V")]
+    version: bool,
+}
+
+fn mount_fs<T: FilesystemMT + Send + Sync + 'static, F>(open: F, mountpoint: PathBuf)
+where
+    F: FnOnce() -> io::Result<T>,
+{
+    let fuse_args: Vec<&OsStr> = vec![&OsStr::new("-o"), &OsStr::new("ro,auto_unmount")];
+
+    match open().map(|fs| fuse_mt::FuseMT::new(fs, 1)) {
+        Ok(fs) => {
+            info!("{}", fl!("info-mounting-as-fuse"));
+            if let Err(e) = fuse_mt::mount(fs, &mountpoint, &fuse_args) {
+                error!("{}", e);
+            }
+        }
+        Err(e) => {
+            error!("{}", e);
+        }
+    }
+}
+
+fn main() -> Result<(), Error> {
+    use std::env::args;
+
+    env_logger::builder()
+        .format_timestamp(None)
+        .filter_level(log::LevelFilter::Off)
+        .parse_default_env()
+        .init();
+
+    let requested_languages = DesktopLanguageRequester::requested_languages();
+    i18n_embed::select(&*LANGUAGE_LOADER, &TRANSLATIONS, &requested_languages).unwrap();
+    age::localizer().select(&requested_languages).unwrap();
+
+    let args = args().collect::<Vec<_>>();
+
+    if console::user_attended() && args.len() == 1 {
+        // If gumdrop ever merges that PR, that can be used here
+        // instead.
+        println!("{} {} [OPTIONS]", fl!("usage-header"), args[0]);
+        println!();
+        println!("{}", AgeMountOptions::usage());
+
+        return Ok(());
+    }
+
+    let opts = AgeMountOptions::parse_args_default_or_exit();
+
+    if opts.version {
+        println!("rage-mount-dir {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    if opts.directory.is_empty() {
+        return Err(Error::MissingSource);
+    }
+    if opts.mountpoint.is_empty() {
+        return Err(Error::MissingMountpoint);
+    }
+
+    let directory = PathBuf::from(opts.directory);
+    if !directory.is_dir() {
+        return Err(Error::SourceMustBeDir);
+    }
+    let mountpoint = PathBuf::from(opts.mountpoint);
+    if !mountpoint.is_dir() {
+        return Err(Error::MountpointMustBeDir);
+    }
+
+    mount_fs(
+        || crate::overlay::AgeOverlayFs::new(directory.into()),
+        mountpoint,
+    );
+    Ok(())
+}

--- a/rage/src/bin/rage-mount-dir/overlay.rs
+++ b/rage/src/bin/rage-mount-dir/overlay.rs
@@ -1,0 +1,350 @@
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use fuse_mt::*;
+use nix::{dir::Dir, fcntl::OFlag, libc, sys::stat::Mode, unistd::AccessFlags};
+use time::Timespec;
+
+use crate::util::*;
+
+pub struct AgeOverlayFs {
+    root: PathBuf,
+    open_dirs: Mutex<HashMap<u64, Dir>>,
+    open_files: Mutex<HashMap<u64, File>>,
+}
+
+impl AgeOverlayFs {
+    pub fn new(root: PathBuf) -> io::Result<Self> {
+        Ok(AgeOverlayFs {
+            root,
+            open_dirs: Mutex::new(HashMap::new()),
+            open_files: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn base_path(&self, path: &Path) -> PathBuf {
+        self.root.join(path.strip_prefix("/").unwrap())
+    }
+}
+
+const TTL: Timespec = Timespec { sec: 1, nsec: 0 };
+
+impl FilesystemMT for AgeOverlayFs {
+    fn getattr(&self, _req: RequestInfo, path: &Path, fh: Option<u64>) -> ResultEntry {
+        use std::os::unix::io::RawFd;
+        nix_err(if let Some(fd) = fh {
+            nix::sys::stat::fstat(fd as RawFd)
+        } else {
+            nix::sys::stat::lstat(&self.base_path(path))
+        })
+        .map(nix_stat)
+        .map(|stat| (TTL, stat))
+    }
+
+    fn chmod(&self, _req: RequestInfo, _path: &Path, _fh: Option<u64>, _mode: u32) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn chown(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn truncate(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _size: u64,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn utimens(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _atime: Option<Timespec>,
+        _mtime: Option<Timespec>,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn utimens_macos(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: Option<u64>,
+        _crtime: Option<Timespec>,
+        _chgtime: Option<Timespec>,
+        _bkuptime: Option<Timespec>,
+        _flags: Option<u32>,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn readlink(&self, _req: RequestInfo, path: &Path) -> ResultData {
+        use std::os::unix::ffi::OsStringExt;
+        nix_err(nix::fcntl::readlink(&self.base_path(path))).map(|s| s.into_vec())
+    }
+
+    fn mknod(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _mode: u32,
+        _rdev: u32,
+    ) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn mkdir(&self, _req: RequestInfo, _parent: &Path, _name: &OsStr, _mode: u32) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn unlink(&self, _req: RequestInfo, _parent: &Path, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn rmdir(&self, _req: RequestInfo, _parent: &Path, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn symlink(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _target: &Path,
+    ) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn rename(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _newparent: &Path,
+        _newname: &OsStr,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn link(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _newparent: &Path,
+        _newname: &OsStr,
+    ) -> ResultEntry {
+        Err(libc::EROFS)
+    }
+
+    fn open(&self, _req: RequestInfo, path: &Path, _flags: u32) -> ResultOpen {
+        use std::os::unix::io::AsRawFd;
+
+        let file = File::open(self.base_path(path)).map_err(|e| e.raw_os_error().unwrap_or(0))?;
+        let fh = file.as_raw_fd() as u64;
+
+        let mut open_files = self.open_files.lock().unwrap();
+        open_files.insert(fh, file);
+
+        Ok((fh, 0))
+    }
+
+    fn read(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        fh: u64,
+        offset: u64,
+        size: u32,
+        callback: impl FnOnce(ResultSlice<'_>) -> CallbackResult,
+    ) -> CallbackResult {
+        let mut open_files = self.open_files.lock().unwrap();
+        let mut buf = vec![0; size as usize];
+        callback(open_files.get_mut(&fh).ok_or(libc::EBADF).and_then(|file| {
+            file.seek(SeekFrom::Start(offset))
+                .and_then(|_| file.read(&mut buf))
+                .map(|bytes| &buf[..bytes])
+                .map_err(|e| e.raw_os_error().unwrap_or(0))
+        }))
+    }
+
+    fn write(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _fh: u64,
+        _offset: u64,
+        _data: Vec<u8>,
+        _flags: u32,
+    ) -> ResultWrite {
+        Err(libc::EROFS)
+    }
+
+    fn flush(&self, _req: RequestInfo, _path: &Path, _fh: u64, _lock_owner: u64) -> ResultEmpty {
+        Ok(())
+    }
+
+    fn release(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+    ) -> ResultEmpty {
+        let mut open_files = self.open_files.lock().unwrap();
+        open_files.remove(&fh).map(|_| ()).ok_or(libc::EBADF)
+    }
+
+    fn fsync(&self, _req: RequestInfo, _path: &Path, _fh: u64, _datasync: bool) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn opendir(&self, _req: RequestInfo, path: &Path, flags: u32) -> ResultOpen {
+        use std::os::unix::io::AsRawFd;
+
+        let oflag = OFlag::from_bits_truncate(flags as i32);
+        let mode = Mode::from_bits_truncate(flags);
+
+        let dir = nix_err(Dir::open(&self.base_path(path), oflag, mode))?;
+        let fh = dir.as_raw_fd() as u64;
+
+        let mut open_dirs = self.open_dirs.lock().unwrap();
+        open_dirs.insert(fh, dir);
+
+        Ok((fh, 0))
+    }
+
+    fn readdir(&self, _req: RequestInfo, _path: &Path, fh: u64) -> ResultReaddir {
+        use std::os::unix::ffi::OsStrExt;
+
+        let mut open_dirs = self.open_dirs.lock().unwrap();
+        let dir = open_dirs.get_mut(&fh).ok_or(libc::EBADF)?;
+
+        dir.iter()
+            .map(nix_err)
+            .map(|res| {
+                res.and_then(|entry| {
+                    let kind = entry
+                        .file_type()
+                        .map(nix_type)
+                        .ok_or(libc::EINVAL)
+                        .or_else(|_| {
+                            nix_err(
+                                nix::sys::stat::fstat(fh as i32)
+                                    .map(nix_stat)
+                                    .map(|stat| stat.kind),
+                            )
+                        })?;
+                    let name = OsStr::from_bytes(entry.file_name().to_bytes()).to_owned();
+                    Ok(DirectoryEntry { name, kind })
+                })
+            })
+            .collect()
+    }
+
+    fn releasedir(&self, _req: RequestInfo, _path: &Path, fh: u64, _flags: u32) -> ResultEmpty {
+        let mut open_dirs = self.open_dirs.lock().unwrap();
+        open_dirs.remove(&fh).map(|_| ()).ok_or(libc::EBADF)
+    }
+
+    fn fsyncdir(&self, _req: RequestInfo, _path: &Path, _fh: u64, _datasync: bool) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn statfs(&self, _req: RequestInfo, path: &Path) -> ResultStatfs {
+        nix_err(nix::sys::statfs::statfs(&self.base_path(path))).map(nix_statfs)
+    }
+
+    fn setxattr(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        _name: &OsStr,
+        _value: &[u8],
+        _flags: u32,
+        _position: u32,
+    ) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    /// Get a file extended attribute.
+    ///
+    /// * `path`: path to the file
+    /// * `name`: attribute name.
+    /// * `size`: the maximum number of bytes to read.
+    ///
+    /// If `size` is 0, return `Xattr::Size(n)` where `n` is the size of the attribute data.
+    /// Otherwise, return `Xattr::Data(data)` with the requested data.
+    fn getxattr(&self, _req: RequestInfo, _path: &Path, _name: &OsStr, _size: u32) -> ResultXattr {
+        Err(libc::ENOSYS)
+    }
+
+    /// List extended attributes for a file.
+    ///
+    /// * `path`: path to the file.
+    /// * `size`: maximum number of bytes to return.
+    ///
+    /// If `size` is 0, return `Xattr::Size(n)` where `n` is the size required for the list of
+    /// attribute names.
+    /// Otherwise, return `Xattr::Data(data)` where `data` is all the null-terminated attribute
+    /// names.
+    fn listxattr(&self, _req: RequestInfo, _path: &Path, _size: u32) -> ResultXattr {
+        Err(libc::ENOSYS)
+    }
+
+    fn removexattr(&self, _req: RequestInfo, _path: &Path, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    fn access(&self, _req: RequestInfo, path: &Path, mask: u32) -> ResultEmpty {
+        let amode = AccessFlags::from_bits_truncate(mask as i32);
+        nix_err(nix::unistd::access(path, amode))
+    }
+
+    fn create(
+        &self,
+        _req: RequestInfo,
+        _parent: &Path,
+        _name: &OsStr,
+        _mode: u32,
+        _flags: u32,
+    ) -> ResultCreate {
+        Err(libc::EROFS)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn setvolname(&self, _req: RequestInfo, _name: &OsStr) -> ResultEmpty {
+        Err(libc::EROFS)
+    }
+
+    // exchange (macOS only, undocumented)
+
+    /// macOS only: Query extended times (bkuptime and crtime).
+    ///
+    /// * `path`: path to the file to get the times for.
+    ///
+    /// Return an `XTimes` struct with the times, or other error code as appropriate.
+    #[cfg(target_os = "macos")]
+    fn getxtimes(&self, _req: RequestInfo, _path: &Path) -> ResultXTimes {
+        Err(libc::ENOSYS)
+    }
+}

--- a/rage/src/bin/rage-mount-dir/reader.rs
+++ b/rage/src/bin/rage-mount-dir/reader.rs
@@ -1,0 +1,70 @@
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use age::stream::StreamReader;
+
+use crate::wrapper::AgeFile;
+
+pub(crate) enum OpenedFile {
+    Normal(File),
+    Age {
+        reader: StreamReader<File>,
+        handle: u64,
+    },
+}
+
+impl OpenedFile {
+    pub(crate) fn normal(path: &Path) -> io::Result<Self> {
+        File::open(path).map(OpenedFile::Normal)
+    }
+
+    pub(crate) fn age(path: &Path, age_file: &AgeFile) -> io::Result<Self> {
+        let file = File::open(path)?;
+
+        use std::os::unix::io::AsRawFd;
+        let handle = file.as_raw_fd() as u64;
+
+        let decryptor = match age::Decryptor::new(file).unwrap() {
+            age::Decryptor::Recipients(d) => d,
+            _ => unreachable!(),
+        };
+        let reader = decryptor
+            .decrypt(
+                Some(&age_file.file_key)
+                    .into_iter()
+                    .map(|i| i as &dyn age::Identity),
+            )
+            .unwrap();
+
+        Ok(OpenedFile::Age { reader, handle })
+    }
+
+    pub(crate) fn handle(&self) -> u64 {
+        match self {
+            OpenedFile::Normal(file) => {
+                use std::os::unix::io::AsRawFd;
+                file.as_raw_fd() as u64
+            }
+            OpenedFile::Age { handle, .. } => *handle,
+        }
+    }
+}
+
+impl io::Read for OpenedFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            OpenedFile::Normal(file) => file.read(buf),
+            OpenedFile::Age { reader, .. } => reader.read(buf),
+        }
+    }
+}
+
+impl io::Seek for OpenedFile {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        match self {
+            OpenedFile::Normal(file) => file.seek(pos),
+            OpenedFile::Age { reader, .. } => reader.seek(pos),
+        }
+    }
+}

--- a/rage/src/bin/rage-mount-dir/util.rs
+++ b/rage/src/bin/rage-mount-dir/util.rs
@@ -1,0 +1,78 @@
+use std::io;
+
+use fuse_mt::*;
+use nix::{
+    libc,
+    sys::stat::{Mode, SFlag},
+};
+use time::Timespec;
+
+pub(crate) fn nix_err<T>(res: nix::Result<T>) -> Result<T, libc::c_int> {
+    // TODO: This clobbers nix-unknown errors to 0.
+    res.map_err(|e| {
+        e.as_errno()
+            .map(io::Error::from)
+            .and_then(|e| e.raw_os_error())
+            .unwrap_or(0)
+    })
+}
+
+pub(crate) fn nix_kind(kind: SFlag) -> FileType {
+    match kind & SFlag::S_IFMT {
+        SFlag::S_IFIFO => FileType::NamedPipe,
+        SFlag::S_IFCHR => FileType::CharDevice,
+        SFlag::S_IFDIR => FileType::Directory,
+        SFlag::S_IFBLK => FileType::BlockDevice,
+        SFlag::S_IFREG => FileType::RegularFile,
+        SFlag::S_IFLNK => FileType::Symlink,
+        SFlag::S_IFSOCK => FileType::Socket,
+        _ => unreachable!(),
+    }
+}
+
+pub(crate) fn nix_type(file_type: nix::dir::Type) -> FileType {
+    use nix::dir::Type;
+    match file_type {
+        Type::Fifo => FileType::NamedPipe,
+        Type::CharacterDevice => FileType::CharDevice,
+        Type::Directory => FileType::Directory,
+        Type::BlockDevice => FileType::BlockDevice,
+        Type::File => FileType::RegularFile,
+        Type::Symlink => FileType::Symlink,
+        Type::Socket => FileType::Socket,
+    }
+}
+
+pub(crate) fn nix_stat(stat: nix::sys::stat::FileStat) -> FileAttr {
+    let kind = SFlag::from_bits_truncate(stat.st_mode);
+    let perm = Mode::from_bits_truncate(stat.st_mode);
+
+    FileAttr {
+        size: stat.st_size as u64,
+        blocks: stat.st_blocks as u64,
+        atime: Timespec::new(stat.st_atime, stat.st_atime_nsec as i32),
+        mtime: Timespec::new(stat.st_mtime, stat.st_mtime_nsec as i32),
+        ctime: Timespec::new(stat.st_ctime, stat.st_ctime_nsec as i32),
+        crtime: Timespec::new(0, 0),
+        kind: nix_kind(kind),
+        perm: perm.bits() as u16,
+        nlink: stat.st_nlink as u32,
+        uid: stat.st_uid,
+        gid: stat.st_gid,
+        rdev: stat.st_rdev as u32,
+        flags: 0,
+    }
+}
+
+pub(crate) fn nix_statfs(statfs: nix::sys::statfs::Statfs) -> Statfs {
+    Statfs {
+        blocks: statfs.blocks(),
+        bfree: 0,
+        bavail: 0,
+        files: statfs.files(),
+        ffree: 0,
+        bsize: statfs.optimal_transfer_size() as u32,
+        namelen: statfs.maximum_name_length() as u32,
+        frsize: statfs.optimal_transfer_size() as u32,
+    }
+}

--- a/rage/src/bin/rage-mount-dir/wrapper.rs
+++ b/rage/src/bin/rage-mount-dir/wrapper.rs
@@ -1,0 +1,97 @@
+use std::{
+    cell::RefCell,
+    fmt,
+    fs::File,
+    io::{self, Seek, SeekFrom},
+    path::PathBuf,
+};
+
+use age::{Decryptor, Identity};
+use age_core::format::{FileKey, Stanza};
+use secrecy::ExposeSecret;
+
+/// A file key we cached. It is bound to the specific stanza it was unwrapped from.
+pub(crate) struct CachedFileKey {
+    stanza: Stanza,
+    inner: FileKey,
+}
+
+impl fmt::Debug for CachedFileKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.stanza.fmt(f)
+    }
+}
+
+impl Identity for CachedFileKey {
+    fn unwrap_stanza(&self, stanza: &Stanza) -> Option<Result<FileKey, age::DecryptError>> {
+        // This compares the entire stanza, including the file key ciphertexts, so we can
+        // be confident that the wrapped file keys are identical, and thus return this
+        // cached file key.
+        if stanza == &self.stanza {
+            Some(Ok(FileKey::from(*self.inner.expose_secret())))
+        } else {
+            None
+        }
+    }
+}
+
+/// A pseudo-identity that caches the first successfully-unwrapped file key.
+struct FileKeyCacher<'a> {
+    identities: &'a [Box<dyn Identity + Send + Sync>],
+    cache: RefCell<Option<CachedFileKey>>,
+}
+
+impl<'a> FileKeyCacher<'a> {
+    fn new(identities: &'a [Box<dyn Identity + Send + Sync>]) -> Self {
+        FileKeyCacher {
+            identities,
+            cache: RefCell::new(None),
+        }
+    }
+}
+
+impl<'a> Identity for FileKeyCacher<'a> {
+    fn unwrap_stanza(&self, stanza: &Stanza) -> Option<Result<FileKey, age::DecryptError>> {
+        self.identities.iter().find_map(|identity| {
+            if let Some(Ok(file_key)) = identity.unwrap_stanza(stanza) {
+                *self.cache.borrow_mut() = Some(CachedFileKey {
+                    stanza: stanza.clone(),
+                    inner: FileKey::from(*file_key.expose_secret()),
+                });
+                Some(Ok(file_key))
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct AgeFile {
+    pub(crate) file_key: CachedFileKey,
+    pub(crate) size: u64,
+}
+
+/// Returns:
+/// - Ok((path, Some(_))) if this is an age file we can decrypt.
+/// - Ok((path, None)) if this is not an age file, or we can't decrypt it.
+pub(crate) fn check_file(
+    path: PathBuf,
+    identities: &[Box<dyn Identity + Send + Sync>],
+) -> io::Result<(PathBuf, Option<AgeFile>)> {
+    let res = if let Ok(Decryptor::Recipients(d)) = Decryptor::new(File::open(&path)?) {
+        let cacher = FileKeyCacher::new(identities);
+        if let Ok(mut r) = d.decrypt(Some(&cacher).into_iter().map(|i| i as &dyn Identity)) {
+            Some(AgeFile {
+                file_key: cacher.cache.into_inner().unwrap(),
+                size: r.seek(SeekFrom::End(0))?,
+            })
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    Ok((path, res))
+}

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -281,7 +281,7 @@ fn main() -> Result<(), Error> {
             }
 
             decryptor
-                .decrypt(identities.iter().map(|i| &**i))
+                .decrypt(identities.iter().map(|i| i.as_ref() as &dyn age::Identity))
                 .map_err(|e| e.into())
                 .and_then(|stream| mount_stream(stream, types, mountpoint))
         }

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -422,7 +422,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
                     &opts.plugin_name,
                     &[plugin::Identity::default_for_plugin(&opts.plugin_name)],
                     UiCallbacks,
-                )?) as Box<dyn Identity>]
+                )?) as Box<dyn Identity + Send + Sync>]
             };
 
             if identities.is_empty() {


### PR DESCRIPTION
Usage: `rage-mount-dir -i IDENTITY [-i IDENTITY ..] DIRECTORY MOUNT_POINT`
- The caller provides a directory to be mounted, and some age identities.
- The directory is transparently mounted at a provided destination.
- Any `*.age` files inside the directory's subtree are checked for decryptability (by the given identities) on first interaction (when the directory containing the file is read).
  - If an age file can be decrypted, it is shown inside the mount point without its `.age` suffix, and with a filesize equivalent to the decrypted file.
  - If an age file cannot be decrypted, it is show unmodified inside the mount point.
- On read, normal files and undecryptable age files are read as-normal, while decryptable age files are transparently decrypted.

Part of #188.