### PR TITLE
*: use Go rather than Golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ age-dev@googlegroups.com. age was designed by
 [@Benjojo12](https://twitter.com/Benjojo12) and
 [@FiloSottile](https://twitter.com/FiloSottile).
 
-The reference interoperable Golang implementation is available at
+The reference interoperable Go implementation is available at
 [filippo.io/age](https://filippo.io/age).
 
 ## Usage

--- a/age/README.md
+++ b/age/README.md
@@ -16,7 +16,7 @@ age-dev@googlegroups.com. age was designed by
 [@Benjojo12](https://twitter.com/Benjojo12) and
 [@FiloSottile](https://twitter.com/FiloSottile).
 
-The reference interoperable Golang implementation is available at
+The reference interoperable Go implementation is available at
 [filippo.io/age](https://filippo.io/age).
 
 ## Usage

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate implements file encryption according to the [age-encryption.org/v1]
 //! specification. It generates and consumes encrypted files that are compatible with the
-//! [rage] CLI tool, as well as the reference [Golang] implementation.
+//! [rage] CLI tool, as well as the reference [Go] implementation.
 //!
 //! The encryption and decryption APIs are provided by [`Encryptor`] and [`Decryptor`].
 //! There are several ways to use these:
@@ -21,7 +21,7 @@
 //!
 //! [age-encryption.org/v1]: https://age-encryption.org/v1
 //! [rage]: https://crates.io/crates/rage
-//! [Golang]: https://filippo.io/age
+//! [Go]: https://filippo.io/age
 //!
 //! # Examples
 //!


### PR DESCRIPTION
This is a common point of confusion in the community, but the proper name of the language is simply "Go". See https://golang.org/doc/faq#go_or_golang.

Thanks for all your work!