### PR TITLE
Header decoding performance improvements

### DIFF
--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -9,6 +9,9 @@ to 1.0.0 are beta releases.
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.51.0.
+- The `body` property of `age_core::format::AgeStanza` has been replaced by the
+  `AgeStanza::body` method, to enable enclosing parsers to defer Base64 decoding
+  until the very end.
 
 ## [0.6.0] - 2021-05-02
 ### Security

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -120,8 +120,9 @@ pub mod read {
     /// ... an arbitrary string is a sequence of ASCII characters with values 33 to 126.
     /// ```
     pub fn arbitrary_string(input: &[u8]) -> IResult<&[u8], &str> {
-        map(take_while1(|c| c >= 33 && c <= 126), |bytes| {
-            std::str::from_utf8(bytes).expect("ASCII is valid UTF-8")
+        map(take_while1(|c| (33..=126).contains(&c)), |bytes| {
+            // Safety: ASCII bytes are valid UTF-8
+            unsafe { std::str::from_utf8_unchecked(bytes) }
         })(input)
     }
 

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -393,4 +393,30 @@ xD7o4VEOu1t7KZQ1gDgq2FPzBEeSRqbnqvQEXdLRYy143BxR6oFxsUUJCRB0ErXA
             .unwrap();
         assert_eq!(buf, test_stanza.as_bytes());
     }
+
+    #[test]
+    fn age_stanza_with_legacy_full_body() {
+        let test_tag = "full-body";
+        let test_args = &["some", "arguments"];
+        let test_body = base64::decode_config(
+            "xD7o4VEOu1t7KZQ1gDgq2FPzBEeSRqbnqvQEXdLRYy143BxR6oFxsUUJCRB0ErXA",
+            base64::STANDARD_NO_PAD,
+        )
+        .unwrap();
+
+        // The body fills a complete line, but lacks a trailing empty line.
+        let test_stanza = "-> full-body some arguments
+xD7o4VEOu1t7KZQ1gDgq2FPzBEeSRqbnqvQEXdLRYy143BxR6oFxsUUJCRB0ErXA
+--- header end
+";
+
+        // The normal parser returns an error.
+        assert!(read::age_stanza(test_stanza.as_bytes()).is_err());
+
+        // We can parse with the legacy parser
+        let (_, stanza) = read::legacy_age_stanza(test_stanza.as_bytes()).unwrap();
+        assert_eq!(stanza.tag, test_tag);
+        assert_eq!(stanza.args, test_args);
+        assert_eq!(stanza.body, test_body);
+    }
 }

--- a/age-core/src/lib.rs
+++ b/age-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 // Catch documentation errors caused by code changes.
 #![deny(broken_intra_doc_links)]
 

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -165,16 +165,12 @@ mod read {
     use super::*;
     use crate::util::read::base64_arg;
 
-    fn recipient_stanza(input: &[u8]) -> IResult<&[u8], Stanza> {
-        map(legacy_age_stanza, Stanza::from)(input)
-    }
-
     fn header_v1(input: &[u8]) -> IResult<&[u8], HeaderV1> {
         preceded(
             pair(tag(V1_MAGIC), newline),
             map(
                 pair(
-                    many1(recipient_stanza),
+                    many1(legacy_age_stanza),
                     preceded(
                         pair(tag(MAC_TAG), tag(b" ")),
                         terminated(
@@ -184,7 +180,7 @@ mod read {
                     ),
                 ),
                 |(recipients, mac)| HeaderV1 {
-                    recipients,
+                    recipients: recipients.into_iter().map(Stanza::from).collect(),
                     mac,
                     encoded_bytes: None,
                 },


### PR DESCRIPTION
Single-stanza headers now take around 55% less time to parse, while multi-header stanzas (benchmarked up to 9) take around 60-70% less time to parse.

This translates to a 25-30% reduction in decryption time for small (<16kB) age files, down to around 5% for 1MB files.