### PR TITLE
add Identity support for RSA PKCS#8 nocrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "scrypt",
  "secrecy",
  "sha2",
+ "simple_asn1",
  "subtle",
  "web-sys",
  "which",
@@ -1342,6 +1343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2164,18 @@ dependencies = [
  "cpufeatures",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -92,6 +92,7 @@ criterion-cycles-per-byte = "0.1"
 futures-test = "0.3"
 quickcheck = "1"
 quickcheck_macros = "1"
+simple_asn1 = "0.5.4"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.5", features = ["criterion", "flamegraph"] }

--- a/age/i18n/en-US/age.ftl
+++ b/age/i18n/en-US/age.ftl
@@ -100,3 +100,9 @@ ssh-unsupported-cipher =
     If you would like support for this key type, please open an issue here:
 
     {$new_issue}
+
+ssh-unsupported-key-format-encrypted-pkcs8 =
+    Unsupported Key Format (PKCS#8)
+    ----------------------------------------
+    See
+    - https://github.com/str4d/rage/issues/15


### PR DESCRIPTION
Hi @str4d,

I realize that this feature is unlikely to see much use in practice, but I picked an old issue that seemed simple enough for a very new rustacean to be able to tackle (first real attempt at Rust).

---

fully parse unencrypted PKCS#8 RSA private key

parse encrypted PKCS#8 enough to recognize it as an unsupported key format

add test coverage for key format support
- PEM (PKCS#1) unencrypted RSA (supported)
- PEM (PKCS#1) encrypted RSA (never support)
- PKCS#8 unencrypted RSA (supported)
- PKCS#8 encrypted (not supported, yet?)

fixes #14