### PR TITLE
Fix panic in `AgeStanza::body`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes",
  "age-core",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "age-plugin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "age-core",
  "bech32",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "rage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "age",
  "chrono",

--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -8,6 +8,16 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 
+## [0.7.1] - 2021-12-27
+### Fixed
+- In 0.7.0, Base64 decoding was moved to the `AgeStanza::body` method, with the
+  stanza parser only checking for valid Base64 characters. This caused the
+  parser to start accepting stanzas with non-canonical last body lines (where
+  the Base64 encoding would have trailing bits that could not be decoded into
+  full bytes); calling `AgeStanza::body` on these stanzas would cause a panic.
+  This release fixes the parser to reject non-canonical last body lines, turning
+  the panic back into an error.
+
 ## [0.7.0] - 2021-10-18
 ### Added
 - `age_core::secrecy`, which re-exports the `secrecy` crate.

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "age-core"
 description = "[BETA] Common functions used across the age crates"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 repository = "https://github.com/str4d/rage"
 readme = "README.md"

--- a/age-plugin/CHANGELOG.md
+++ b/age-plugin/CHANGELOG.md
@@ -10,6 +10,11 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 
+## [0.2.1] - 2021-12-27
+### Fixed
+- Bumped `age-core` to 0.7.1 to fix a bug where non-canonical recipient stanza
+  bodies in an age file header would cause a panic instead of being rejected.
+
 ## [0.2.0] - 2021-10-18
 ### Changed
 - MSRV is now 1.51.0.

--- a/age-plugin/Cargo.toml
+++ b/age-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "age-plugin"
 description = "[BETA] API for writing age plugins."
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 repository = "https://github.com/str4d/rage"
 readme = "README.md"
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-age-core = { version = "0.7.0", path = "../age-core", features = ["plugin"] }
+age-core = { version = "0.7.1", path = "../age-core", features = ["plugin"] }
 bech32 = "0.8"
 chrono = "0.4"
 

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -10,6 +10,11 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 
+## [0.7.1] - 2021-12-27
+### Fixed
+- Bumped `age-core` to 0.7.1 to fix a bug where non-canonical recipient stanza
+  bodies in an age file header would cause a panic instead of being rejected.
+
 ## [0.7.0] - 2021-10-18
 ### Added
 - `age::encrypted::Identity`, for decrypting files with passphrase-encrypted

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "age"
 description = "[BETA] A simple, secure, and modern encryption library."
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 repository = "https://github.com/str4d/rage"
 readme = "README.md"
@@ -14,7 +14,7 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
-age-core = { version = "0.7.0", path = "../age-core" }
+age-core = { version = "0.7.1", path = "../age-core" }
 
 # Dependencies required by the age specification:
 # - Base64 from RFC 4648

--- a/fuzz-afl/Cargo.lock
+++ b/fuzz-afl/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "age-core",
  "base64",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "chacha20poly1305",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "age-core",
  "base64",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "chacha20poly1305",

--- a/fuzz/fuzz_targets/age_stanza.rs
+++ b/fuzz/fuzz_targets/age_stanza.rs
@@ -7,7 +7,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok((leftover, stanza)) = read::age_stanza(data) {
         let mut buf = Vec::with_capacity(data.len());
         gen(
-            write::age_stanza(stanza.tag, &stanza.args, &stanza.body),
+            write::age_stanza(stanza.tag, &stanza.args, &stanza.body()),
             &mut buf,
         )
         .expect("can write to Vec");

--- a/fuzz/fuzz_targets/decrypt.rs
+++ b/fuzz/fuzz_targets/decrypt.rs
@@ -1,16 +1,18 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
+use std::iter;
+
 use age::Decryptor;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(decryptor) = Decryptor::new(data) {
         match decryptor {
             Decryptor::Recipients(d) => {
-                let _ = d.decrypt(&[]);
+                let _ = d.decrypt(iter::empty());
             }
             // Don't pay the cost of scrypt while fuzzing.
-            Decryptor::Passphrase(_) => ()
+            Decryptor::Passphrase(_) => (),
         }
     }
 });

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -10,6 +10,11 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 
+## [0.7.1] - 2021-12-27
+### Fixed
+- Fixed a bug in 0.7.0 where non-canonical recipient stanza bodies in an age
+  file header would cause `rage` to crash instead of being rejected.
+
 ## [0.7.0] - 2021-10-18
 ### Added
 - `-i/--identity` now accepts passphrase-encrypted age identity files.

--- a/rage/Cargo.toml
+++ b/rage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rage"
 description = "[BETA] A simple, secure, and modern encryption tool."
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 repository = "https://github.com/str4d/rage"
 readme = "../README.md"
@@ -43,7 +43,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 # rage and rage-keygen dependencies
-age = { version = "0.7.0", path = "../age", features = ["armor", "cli-common", "plugin"] }
+age = { version = "0.7.1", path = "../age", features = ["armor", "cli-common", "plugin"] }
 chrono = "0.4"
 console = { version = "0.15", default-features = false }
 env_logger = "0.9"


### PR DESCRIPTION
In 0.7.0, Base64 decoding was moved to the `AgeStanza::body` method, with the stanza parser only checking for valid Base64 characters. This caused the parser to start accepting stanzas with non-canonical last body lines (where the Base64 encoding would have trailing bits that could not be decoded into full bytes); calling `AgeStanza::body` on these stanzas would cause a panic.

We fix the parser to reject non-canonical last body lines, turning the panic back into an error.