### PR TITLE
Resolve compiler errors for incompatible feature combinations

### DIFF
--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -13,7 +13,10 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use subtle::ConstantTimeEq;
 
-use crate::{armor::ArmoredReader, fl, identity::IdentityFile, wfl, Callbacks, Identity};
+use crate::{fl, identity::IdentityFile, wfl, Callbacks, Identity};
+
+#[cfg(feature = "armor")]
+use crate::armor::ArmoredReader;
 
 pub mod file_io;
 
@@ -108,6 +111,7 @@ pub fn read_identities(
     let mut identities: Vec<Box<dyn Identity>> = vec![];
 
     for filename in filenames {
+        #[cfg(feature = "armor")]
         // Try parsing as an encrypted age identity.
         if let Ok(identity) = crate::encrypted::Identity::from_buffer(
             ArmoredReader::new(BufReader::new(File::open(&filename)?)),

--- a/age/src/encrypted.rs
+++ b/age/src/encrypted.rs
@@ -215,9 +215,10 @@ mod tests {
     use age_core::secrecy::{ExposeSecret, SecretString};
 
     use super::Identity;
-    use crate::{
-        armor::ArmoredReader, x25519, Callbacks, DecryptError, Identity as _, Recipient as _,
-    };
+    use crate::{x25519, Callbacks, DecryptError, Identity as _, Recipient as _};
+
+    #[cfg(feature = "armor")]
+    use crate::armor::ArmoredReader;
 
     const TEST_ENCRYPTED_IDENTITY_PASSPHRASE: &str = "foobar";
 
@@ -260,6 +261,7 @@ fOrxrKTj7xCdNS3+OrCdnBC8Z9cKDxjCGWW3fkjLsYha0Jo=
     }
 
     #[test]
+    #[cfg(feature = "armor")]
     fn round_trip() {
         let pk: x25519::Recipient = TEST_RECIPIENT.parse().unwrap();
         let file_key = [12; 16].into();

--- a/age/tests/test_vectors.rs
+++ b/age/tests/test_vectors.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::Read;
 
 #[test]
+#[cfg(feature = "cli-common")]
 fn age_test_vectors() -> Result<(), Box<dyn std::error::Error>> {
     for test_vector in fs::read_dir("./tests/testdata")?.filter(|res| {
         res.as_ref()


### PR DESCRIPTION
Some places in the code rely on features without conditional compilation for that code. This causes compiler errors for some combinations of features. 

For example, having the `cli-common` feature enabled but not the `plugin` feature resulted in a compiler error because `IdentityFileEntry::into_identity` could return a `ReadError::MissingPlugin`, which is disabled when the `plugin` feature is disabled.

These commits address a few of these cases where compiler errors are emitted. The patched version passes the tests for all members of the power set of the features `["armor", "async", "cli-common", "plugin", "ssh"]`. This was tested using
[https://github.com/frewsxcv/cargo-all-features](https://github.com/frewsxcv/cargo-all-features).

This only resolves compiler errors, but if this was helpful, I can look into addressing the warnings, too.