### PR TITLE
age: Allow ciphertexts that encrypt the empty plaintext

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -24,8 +24,9 @@ to 1.0.0 are beta releases.
   will write to a stdout TTY, it buffers the entire output so it doesn't get in
   the way of typing the input, and then writes the buffered output to stdout
   during `OutputWriter::flush`.
-- Ciphertexts are now required to end in a non-empty STREAM chunk. Neither age
-  nor rage generate files ending in an empty chunk, instead marking the final
+- Ciphertexts are now required to end in a non-empty STREAM chunk, unless it is
+  the only chunk (meaning that the plaintext is empty). Neither age nor rage
+  generate non-empty files ending in an empty chunk, instead marking the final
   full chunk as the last chunk.
 
 ## [0.7.1] - 2021-12-27


### PR DESCRIPTION
In str4d/rage#319 we required the last STREAM chunk to be non-empty, as this is generally non-canonical (and can be represented instead by the chunk marked as last being full). The sole exception to this is if the plaintext has length zero, in which case there is no "previous" chunk, and the single empty chunk is the canonical representation.

There generally isn't a good reason to create empty age ciphertexts, as most identities don't provide authentication guarantees, but we've allowed them in the past.