### PR TITLE
Fix test and bench support for ARM CPUs

### DIFF
--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -91,7 +91,6 @@ wsl = { version = "0.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-criterion-cycles-per-byte = "0.1"
 futures-test = "0.3"
 i18n-embed = { version = "0.13", features = ["desktop-requester", "fluent-system"] }
 quickcheck = "1"
@@ -99,6 +98,9 @@ quickcheck_macros = "1"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.8", features = ["criterion", "flamegraph"] }
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dev-dependencies]
+criterion-cycles-per-byte = "0.1"
 
 [features]
 default = []


### PR DESCRIPTION
`cargo test` currently fails on Apple M1 processors with this error:

```
   Compiling i18n-embed v0.13.4
   Compiling i18n-embed-fl v0.6.4
   Compiling criterion-cycles-per-byte v0.1.2
error: criterion-cycles-per-byte currently relies on x86 or x86_64.
  --> /Users/macil/.cargo/registry/src/github.com-1ecc6299db9ec823/criterion-cycles-per-byte-0.1.2/src/lib.rs:34:1
   |
34 | compile_error!("criterion-cycles-per-byte currently relies on x86 or x86_64.");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
  --> /Users/macil/.cargo/registry/src/github.com-1ecc6299db9ec823/criterion-cycles-per-byte-0.1.2/src/lib.rs:41:15
   |
41 | fn rdtsc() -> u64 {
   |    -----      ^^^ expected `u64`, found `()`
   |    |
   |    implicitly returns `()` as its body has no tail or `return` expression

For more information about this error, try `rustc --explain E0308`.
error: could not compile `criterion-cycles-per-byte` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```

This PR disables the criterion-cycles-per-byte dev dependency when not on x86 or x86_64. `cargo test` and `cargo bench` work on Apple M1 now.