### PR TITLE
age/ssh: make `ssh::Identity: Clone`

### DIFF
--- a/age/src/ssh.rs
+++ b/age/src/ssh.rs
@@ -89,6 +89,7 @@ impl OpenSshKdf {
 }
 
 /// An encrypted SSH private key.
+#[derive(Clone)]
 pub struct EncryptedKey {
     ssh_key: Vec<u8>,
     cipher: OpenSshCipher,

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 
 /// An SSH private key for decrypting an age file.
+#[derive(Clone)]
 pub enum UnencryptedKey {
     /// An ssh-rsa private key.
     SshRsa(Vec<u8>, Box<rsa::RsaPrivateKey>),
@@ -194,6 +195,7 @@ impl UnsupportedKey {
 }
 
 /// An SSH private key for decrypting an age file.
+#[derive(Clone)]
 pub enum Identity {
     /// An unencrypted key.
     Unencrypted(UnencryptedKey),


### PR DESCRIPTION
This makes SSH identities cloneable, which is consistent with age identities.

No functional changes otherwise.