### PR TITLE
Fix tests on non-unix non-x86/64

### DIFF
--- a/age/benches/throughput.rs
+++ b/age/benches/throughput.rs
@@ -95,8 +95,7 @@ criterion_group!(
 #[cfg(not(unix))]
 criterion_group!(
     name = benches;
-    config = setup_criterion()
-        .with_measurement(CyclesPerByte);
+    config = setup_criterion();
     targets = bench
 );
 criterion_main!(benches);


### PR DESCRIPTION
Follow-up to https://github.com/str4d/rage/pull/322. This PR removes a call to `.with_measurement(CyclesPerByte)` which was merely redundant on x86/64 systems, but would cause a compile error on non-Unix non-x86/64 systems. (Non-x86/64 test runs were already broken prior to #322 so it wasn't a regression.)

Related comment: https://github.com/str4d/rage/pull/322/files#r912559075