### PR TITLE
Allow for the configuration of the scrypt work factor used for encryption

### DIFF
--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -152,7 +152,7 @@ mod util;
 pub use error::{DecryptError, EncryptError};
 pub use identity::{IdentityFile, IdentityFileEntry};
 pub use primitives::stream;
-pub use protocol::{decryptor, Decryptor, Encryptor};
+pub use protocol::{decryptor, Decryptor, Encryptor, WorkFactor};
 
 #[cfg(feature = "armor")]
 pub use primitives::armor;


### PR DESCRIPTION
I made some experimental changes that allow the use to have more control over what work factor is use for scrypt during encryption. 
The documentation is currently lacking, but I wanted to see if you're generally on board with these changes before putting more effort into it.