### PR TITLE
Use homebrew's rust install stanza

### DIFF
--- a/HomebrewFormula/rage.rb
+++ b/HomebrewFormula/rage.rb
@@ -8,9 +8,7 @@ class Rage < Formula
     depends_on "rust" => :build
 
     def install
-        system "cargo", "build", "--release", "--package", "rage"
-        bin.install "target/release/rage"
-        bin.install "target/release/rage-keygen"
+      system "cargo", "install", *std_cargo_args(path: './rage')
     end
 
     test do

--- a/HomebrewFormula/rage.rb
+++ b/HomebrewFormula/rage.rb
@@ -8,7 +8,7 @@ class Rage < Formula
     depends_on "rust" => :build
 
     def install
-      system "cargo", "install", *std_cargo_args(path: './rage')
+        system "cargo", "install", *std_cargo_args(path: './rage')
     end
 
     test do


### PR DESCRIPTION
Homebrew has methods to pass common arguments for several languages' build systems. You can find examples by searching for packaged rust software in [homebrew core](https://github.com/Homebrew/homebrew-core/tree/master/Formula). Diesel, rg, and procs are good examples.