### PR TITLE
Prevent `age::Encryptor` from being constructed with no recipients

### DIFF
--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Changed
+- Migrated to `aead 0.5`.
 
 ## [0.8.0] - 2022-05-02
 ### Added

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -12,6 +12,8 @@ to 1.0.0 are beta releases.
 ### Added
 - `age::armor::ArmoredReadError`, used to wrap armor-specific read errors inside
   `std::io::Error`.
+- `age::ssh`:
+  - `impl Clone for Identity`
 
 ### Fixed
 - `age::Decryptor` now rejects invalid or non-canonical `scrypt` recipient

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -15,6 +15,11 @@ to 1.0.0 are beta releases.
 - `age::ssh`:
   - `impl Clone for Identity`
 
+### Changed
+- `age::Encryptor::with_recipients` now returns `Option<Encryptor>`, with `None`
+  returned if the provided list of recipients is empty (to prevent files being
+  encrypted to no recipients).
+
 ### Fixed
 - `age::Decryptor` now rejects invalid or non-canonical `scrypt` recipient
   stanzas (instead of ignoring or accepting them respectively), matching the

--- a/age/benches/parser.rs
+++ b/age/benches/parser.rs
@@ -24,6 +24,7 @@ fn bench(c: &mut Criterion) {
                     .map(|r| r as Box<dyn Recipient>)
                     .collect(),
             )
+            .unwrap()
             .wrap_output(&mut encrypted)
             .unwrap();
             output.write_all(&[]).unwrap();

--- a/age/benches/throughput.rs
+++ b/age/benches/throughput.rs
@@ -53,6 +53,7 @@ fn bench(c: &mut Criterion_) {
         group.bench_function(BenchmarkId::new("encrypt", size), |b| {
             b.iter(|| {
                 let mut output = Encryptor::with_recipients(vec![Box::new(recipient.clone())])
+                    .unwrap()
                     .wrap_output(io::sink())
                     .unwrap();
                 output.write_all(&pt_buf[..size]).unwrap();
@@ -62,6 +63,7 @@ fn bench(c: &mut Criterion_) {
 
         group.bench_function(BenchmarkId::new("decrypt", size), |b| {
             let mut output = Encryptor::with_recipients(vec![Box::new(recipient.clone())])
+                .unwrap()
                 .wrap_output(&mut ct_buf)
                 .unwrap();
             output.write_all(&pt_buf[..size]).unwrap();

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -40,7 +40,8 @@
 //! // Encrypt the plaintext to a ciphertext...
 //! # fn encrypt(pubkey: age::x25519::Recipient, plaintext: &[u8]) -> Result<Vec<u8>, age::EncryptError> {
 //! let encrypted = {
-//!     let encryptor = age::Encryptor::with_recipients(vec![Box::new(pubkey)]);
+//!     let encryptor = age::Encryptor::with_recipients(vec![Box::new(pubkey)])
+//!         .expect("we provided a recipient");
 //!
 //!     let mut encrypted = vec![];
 //!     let mut writer = encryptor.wrap_output(&mut encrypted)?;

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -59,10 +59,12 @@ enum EncryptorType {
 pub struct Encryptor(EncryptorType);
 
 impl Encryptor {
-    /// Returns an `Encryptor` that will create an age file encrypted to a list of
+    /// Constructs an `Encryptor` that will create an age file encrypted to a list of
     /// recipients.
-    pub fn with_recipients(recipients: Vec<Box<dyn Recipient>>) -> Self {
-        Encryptor(EncryptorType::Keys(recipients))
+    ///
+    /// Returns `None` if no recipients were provided.
+    pub fn with_recipients(recipients: Vec<Box<dyn Recipient>>) -> Option<Self> {
+        (!recipients.is_empty()).then(|| Encryptor(EncryptorType::Keys(recipients)))
     }
 
     /// Returns an `Encryptor` that will create an age file encrypted with a passphrase.
@@ -242,7 +244,7 @@ mod tests {
         let test_msg = b"This is a test message. For testing.";
 
         let mut encrypted = vec![];
-        let e = Encryptor::with_recipients(recipients);
+        let e = Encryptor::with_recipients(recipients).unwrap();
         {
             let mut w = e.wrap_output(&mut encrypted).unwrap();
             w.write_all(test_msg).unwrap();
@@ -269,7 +271,7 @@ mod tests {
         let mut cx = noop_context();
 
         let mut encrypted = vec![];
-        let e = Encryptor::with_recipients(recipients);
+        let e = Encryptor::with_recipients(recipients).unwrap();
         {
             let w = {
                 let f = e.wrap_async_output(&mut encrypted);

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to Rust's notion of
 to 1.0.0 are beta releases.
 
 ## [Unreleased]
+### Fixed
+- Encryption now returns an error if the file would be encrypted to no
+  recipients. This can occur if only `-R/--recipients-file` flags are provided,
+  and they all point to files that contain only "#" prefixed comments and empty
+  lines.
 
 ## [0.8.1] - 2022-06-18
 ### Security

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -377,12 +377,15 @@ fn encrypt(opts: AgeOptions) -> Result<(), error::EncryptError> {
             return Err(error::EncryptError::MissingRecipients);
         }
 
-        age::Encryptor::with_recipients(read_recipients(
+        match age::Encryptor::with_recipients(read_recipients(
             opts.recipient,
             opts.recipients_file,
             opts.identity,
             opts.max_work_factor,
-        )?)
+        )?) {
+            Some(encryptor) => encryptor,
+            None => return Err(error::EncryptError::MissingRecipients),
+        }
     };
 
     let (format, output_format) = if opts.armor {


### PR DESCRIPTION
This removes the ability to encrypt a file to no recipients, which serves no useful purpose.
    
`rage` already required that recipient arguments be provided, but now it additionally requires that provided recipient files are not empty.
    
Closes str4d/rage#330.