### PR TITLE
Ensure Encryptor implements trait Send

### DIFF
--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -50,7 +50,7 @@ impl Nonce {
 /// Handles the various types of age encryption.
 enum EncryptorType {
     /// Encryption to a list of recipients identified by keys.
-    Keys(Vec<Box<dyn Recipient>>),
+    Keys(Vec<Box<dyn Recipient + Send>>),
     /// Encryption to a passphrase.
     Passphrase(SecretString),
 }
@@ -63,7 +63,7 @@ impl Encryptor {
     /// recipients.
     ///
     /// Returns `None` if no recipients were provided.
-    pub fn with_recipients(recipients: Vec<Box<dyn Recipient>>) -> Option<Self> {
+    pub fn with_recipients(recipients: Vec<Box<dyn Recipient + Send>>) -> Option<Self> {
         (!recipients.is_empty()).then(|| Encryptor(EncryptorType::Keys(recipients)))
     }
 


### PR DESCRIPTION
By adding the Send trait as a requirement to the recipients vec, we gain the Send trait on Encryptor. This is useful for other async frameworks that require Send across await's.