### PR TITLE
Initialize Vector With Capacity When Known

### DIFF
--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -108,7 +108,7 @@ pub fn read_identities(
     filenames: Vec<String>,
     max_work_factor: Option<u8>,
 ) -> Result<Vec<Box<dyn Identity>>, ReadError> {
-    let mut identities: Vec<Box<dyn Identity>> = vec![];
+    let mut identities: Vec<Box<dyn Identity>> = Vec::with_capacity(filenames.len());
 
     for filename in filenames {
         #[cfg(feature = "armor")]

--- a/age/src/scrypt.rs
+++ b/age/src/scrypt.rs
@@ -84,9 +84,9 @@ impl crate::Recipient for Recipient {
         let mut salt = [0; SALT_LEN];
         OsRng.fill_bytes(&mut salt);
 
-        let mut inner_salt = vec![];
-        inner_salt.extend_from_slice(SCRYPT_SALT_LABEL);
-        inner_salt.extend_from_slice(&salt);
+        let mut inner_salt = [0; SCRYPT_SALT_LABEL.len() + SALT_LEN];
+        inner_salt[..SCRYPT_SALT_LABEL.len()].copy_from_slice(SCRYPT_SALT_LABEL);
+        inner_salt[SCRYPT_SALT_LABEL.len()..].copy_from_slice(&salt);
 
         let log_n = target_scrypt_work_factor();
 
@@ -137,9 +137,9 @@ impl<'a> crate::Identity for Identity<'a> {
             }));
         }
 
-        let mut inner_salt = vec![];
-        inner_salt.extend_from_slice(SCRYPT_SALT_LABEL);
-        inner_salt.extend_from_slice(&salt);
+        let mut inner_salt = [0; SCRYPT_SALT_LABEL.len() + SALT_LEN];
+        inner_salt[..SCRYPT_SALT_LABEL.len()].copy_from_slice(SCRYPT_SALT_LABEL);
+        inner_salt[SCRYPT_SALT_LABEL.len()..].copy_from_slice(&salt);
 
         let enc_key = match scrypt(&inner_salt, log_n, self.passphrase.expose_secret()) {
             Ok(k) => k,

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -96,9 +96,9 @@ impl UnencryptedKey {
                 let shared_secret = tweak
                     .diffie_hellman(&X25519PublicKey::from(*sk.diffie_hellman(&epk).as_bytes()));
 
-                let mut salt = vec![];
-                salt.extend_from_slice(epk.as_bytes());
-                salt.extend_from_slice(pk.as_bytes());
+                let mut salt = [0; 64];
+                salt[..32].copy_from_slice(epk.as_bytes());
+                salt[32..].copy_from_slice(pk.as_bytes());
 
                 let enc_key = hkdf(
                     &salt,

--- a/age/src/ssh/recipient.rs
+++ b/age/src/ssh/recipient.rs
@@ -147,9 +147,9 @@ impl crate::Recipient for Recipient {
                 let shared_secret =
                     tweak.diffie_hellman(&(*esk.diffie_hellman(&pk).as_bytes()).into());
 
-                let mut salt = vec![];
-                salt.extend_from_slice(epk.as_bytes());
-                salt.extend_from_slice(pk.as_bytes());
+                let mut salt = [0; 64];
+                salt[..32].copy_from_slice(epk.as_bytes());
+                salt[32..].copy_from_slice(pk.as_bytes());
 
                 let enc_key = hkdf(
                     &salt,

--- a/age/src/x25519.rs
+++ b/age/src/x25519.rs
@@ -120,9 +120,9 @@ impl crate::Identity for Identity {
             return Some(Err(DecryptError::InvalidHeader));
         }
 
-        let mut salt = vec![];
-        salt.extend_from_slice(epk.as_bytes());
-        salt.extend_from_slice(pk.as_bytes());
+        let mut salt = [0; 64];
+        salt[..32].copy_from_slice(epk.as_bytes());
+        salt[32..].copy_from_slice(pk.as_bytes());
 
         let enc_key = hkdf(&salt, X25519_RECIPIENT_KEY_LABEL, shared_secret.as_bytes());
 
@@ -204,9 +204,9 @@ impl crate::Recipient for Recipient {
             panic!("Generated the all-zero esk; OS RNG is likely failing!");
         }
 
-        let mut salt = vec![];
-        salt.extend_from_slice(epk.as_bytes());
-        salt.extend_from_slice(self.0.as_bytes());
+        let mut salt = [0; 64];
+        salt[..32].copy_from_slice(epk.as_bytes());
+        salt[32..].copy_from_slice(self.0.as_bytes());
 
         let enc_key = hkdf(&salt, X25519_RECIPIENT_KEY_LABEL, shared_secret.as_bytes());
         let encrypted_file_key = aead_encrypt(&enc_key, file_key.expose_secret());


### PR DESCRIPTION
# Overview

There's a few places within the codebase where vectors are declared, but not initialized with any capacity, ie `let a = vec![]`. When one knows in advance with reasonable certainty the size of the data that the vector will hold, initializing the vector with that size as the capacity can potentially save on allocations.

For example consider this line without the pre-initialization

```rust
                // vector initialized without capacity
                let mut salt = vec![];
                // memory is allocated for 32 bytes and then the the bytes of `epk` pushed onto the vec
                // total memory allocated: 32 bytes
                salt.extend_from_slice(epk.as_bytes()); 
                // to avoid excessive allocations, rust will allocate twice the capacity (64 bytes)
                // total memory allocated: 96 bytes
                salt.extend_from_slice(pk.as_bytes());

                // total memory allocation cycles: 2
```

Now consider the following which uses a pre-initialized capacity

```rust
                // vector initialized with a capacity of 64 bytes
                // as we know the values returned by `pk.as_bytes()` and `epk.as_bytes()` are 32 bytes each
                // total memory allocated: 64 bytes
                let mut salt = Vec::with_capacity(64);
                // capacity is sufficient, no allocations
                // total memory allocated: 64 bytes
                salt.extend_from_slice(epk.as_bytes()); 
                // capacity is sufficient, no allocations
                // total memory allocated: 64 bytes
                salt.extend_from_slice(pk.as_bytes());

                // total memory allocation cycles: 1
```

So as is demonstrated above, in these circumstances by using pre-initialized vectors memory usage is reduced by 32 bytes, and there will be 1 less syscall since an additional memory allocation cycle is avoided.