### PR TITLE
feat/pinentry: Use env var to define pinentry binary

### DIFF
--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -221,8 +221,16 @@ pub fn read_secret(
     prompt: &str,
     confirm: Option<&str>,
 ) -> pinentry::Result<SecretString> {
-    if let Some(mut input) = PassphraseInput::with_default_binary() {
-        // pinentry binary is available!
+    // Check for the pinentry environment variable. If it's not present try to use the default
+    // binary.
+    let input = if let Ok(pinentry) = std::env::var("RAGE_PINENTRY") {
+        PassphraseInput::with_binary(pinentry)
+    } else {
+        PassphraseInput::with_default_binary()
+    };
+
+    if let Some(mut input) = input {
+        // User-set or default pinentry binary is available!
         let mismatch_error = fl!("cli-secret-input-mismatch");
         let empty_error = fl!("cli-secret-input-required");
         input


### PR DESCRIPTION
Hello,

as discussed in #280 this PR adds the possibility to specify a pinentry binary via a environment variable.

I can understand that you are hesitant to add/keep the pinentry complexity. In my case I use rage/passage together with [passff](https://github.com/passff/passff). If I want to decrypt a password in the browser, I need a possibility to do this using a GUI. Thus, I would like to see this feature being present.

If you agree with the PR, I can also add the respective documentation.

Best