### PR TITLE
Allow disabling greasing the joint via feature flag

### DIFF
--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -111,6 +111,7 @@ default = []
 armor = []
 async = ["futures", "memchr"]
 cli-common = ["atty", "console", "pinentry", "rpassword"]
+fatfree = []
 plugin = ["age-core/plugin", "which", "wsl"]
 ssh = [
     "aes",

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Encryption and decryption routines for age.
 
-use age_core::{format::grease_the_joint, secrecy::SecretString};
+use age_core::secrecy::SecretString;
 use rand::{rngs::OsRng, RngCore};
 use std::io::{self, Read, Write};
 
@@ -89,8 +89,10 @@ impl Encryptor {
                 for recipient in recipients {
                     stanzas.append(&mut recipient.wrap_file_key(&file_key)?);
                 }
-                // Keep the joint well oiled!
-                stanzas.push(grease_the_joint());
+                #[cfg(not(feature = "fatfree"))] {
+                    // Keep the joint well oiled!
+                    stanzas.push(age_core::format::grease_the_joint());
+                }
                 stanzas
             }
             EncryptorType::Passphrase(passphrase) => {


### PR DESCRIPTION
It's a little off-putting in actual use to find "weird" recipients in the stanza, and the only way to ensure there's no "backdoor" hiding there is verifying the code.

If you want to grease by default, why do the keys get greased but not the passphrases?

I also wasn't sure if you'd like `Cargo.lock` checked in with PRs or not.