### PR TITLE
Correct spelling in documentation

### DIFF
--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -1,4 +1,4 @@
-//! *Library for encrypting and decryping age files*
+//! *Library for encrypting and decrypting age files*
 //!
 //! This crate implements file encryption according to the [age-encryption.org/v1]
 //! specification. It generates and consumes encrypted files that are compatible with the


### PR DESCRIPTION
Sorry for such a minor change, but it is the first line of the documentation and I couldn't help seeing it.