### PR TITLE
age: Replace callback input `read_line_initial_text` with `write_str` and `read_line`

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -16,6 +16,13 @@ to 1.0.0 are beta releases.
 - MSRV is now 1.65.0.
 - Migrated to `base64 0.21`, `rsa 0.9`.
 
+### Fixed
+- `age::cli_common`:
+  - `UiCallbacks::confirm` no longer requires erasing the confirmation message
+    before it will accept a response.
+  - `UiCallbacks::request_public_string` no longer prepends the description to
+    the response string.
+
 ## [0.9.2] - 2023-06-12
 ### Added
 - `age::Decryptor::{new_buffered, new_async_buffered}`, which are more efficient

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -189,7 +189,8 @@ fn confirm(query: &str, ok: &str, cancel: Option<&str>) -> pinentry::Result<bool
         let term = console::Term::stderr();
         let initial = format!("{}: (y/n) ", query);
         loop {
-            let response = term.read_line_initial_text(&initial)?.to_lowercase();
+            term.write_str(&initial)?;
+            let response = term.read_line()?.to_lowercase();
             if ["y", "yes"].contains(&response.as_str()) {
                 break Ok(true);
             } else if ["n", "no"].contains(&response.as_str()) {
@@ -284,9 +285,8 @@ impl Callbacks for UiCallbacks {
 
     fn request_public_string(&self, description: &str) -> Option<String> {
         let term = console::Term::stderr();
-        term.read_line_initial_text(description)
-            .ok()
-            .filter(|s| !s.is_empty())
+        term.write_str(description).ok()?;
+        term.read_line().ok().filter(|s| !s.is_empty())
     }
 
     fn request_passphrase(&self, description: &str) -> Option<SecretString> {


### PR DESCRIPTION
`read_line_initial_text` fills the tty input with the initial text. This implies that the returned input is usually prefixed with the initial text, or that the initial text can be removed.
This differs from `age` behaviour, which is to not allow the initial text to be removed.

As a consequence, plugin leveraging callbacks for reading public input (confirm, request_public_string) exhibit a different behaviour depending on if they are called with `age` or `rage`.

This commit replaces `read_line_initial_text` with `write_str` and `read_line`. The initial text is still displayed to the user, but it does not affect the returned output.