### PR TITLE
age: scrypt fix work factor calculation with bad SystemTime precision

### DIFF
--- a/age/src/scrypt.rs
+++ b/age/src/scrypt.rs
@@ -62,6 +62,7 @@ fn target_scrypt_work_factor() -> u8 {
     };
 
     duration
+        .and_then(|d| (!d.is_zero()).then_some(d))
         .map(|mut d| {
             // Use duration as a proxy for CPU usage, which scales linearly with N.
             while d < ONE_SECOND && log_n < 63 {


### PR DESCRIPTION
This PR fixes issue https://github.com/str4d/rage/issues/418

Uses default scrypt work factor if the duration of one scrypt encryption is below SystemTime precision.