### PR TITLE
Improve errors and changelogs for larger RSA keys

### DIFF
--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -15,6 +15,14 @@ to 1.0.0 are beta releases.
 ### Changed
 - MSRV is now 1.65.0.
 - Migrated to `base64 0.21`, `rsa 0.9`.
+- `age::ssh`:
+  - `ParseRecipientKeyError` has a new variant `RsaModulusTooLarge`.
+  - The following trait implementations now return
+    `Err(ParseRecipientKeyError::RsaModulusTooLarge)` instead of
+    `Err(ParseRecipientKeyError::Unsupported(_))` when encountering an RSA
+    public key with a modulus larger than 4096 bits:
+    - `impl FromStr for Recipient`
+    - `impl TryFrom<Identity> for Recipient`
 
 ### Fixed
 - `age::cli_common`:

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -47,6 +47,11 @@ to 1.0.0 are beta releases.
 - Support for encrypted OpenSSH keys exported from 1Password.
 
 ## [0.9.0] - 2022-10-27
+### Security
+- `age::ssh::Recipient::SshRsa` now has a maximum modulus size of 4096 bits, to
+  prevent a Denial of Service (DoS) condition when encrypting to untrusted
+  public keys.
+
 ### Added
 - `age::armor::ArmoredReadError`, used to wrap armor-specific read errors inside
   `std::io::Error`.
@@ -55,6 +60,7 @@ to 1.0.0 are beta releases.
 
 ### Changed
 - MSRV is now 1.59.0.
+- Migrated to `rsa 0.7`.
 - `age::Encryptor::with_recipients` now returns `Option<Encryptor>`, with `None`
   returned if the provided list of recipients is empty (to prevent files being
   encrypted to no recipients). The `recipients` argument is also now

--- a/age/src/ssh.rs
+++ b/age/src/ssh.rs
@@ -489,13 +489,17 @@ mod read_ssh {
     /// mpint     e
     /// mpint     n
     /// ```
-    pub(super) fn rsa_pubkey(input: &[u8]) -> IResult<&[u8], rsa::RsaPublicKey> {
-        preceded(
-            string_tag(SSH_RSA_KEY_PREFIX),
-            map_res(tuple((mpint, mpint)), |(exponent, modulus)| {
-                rsa::RsaPublicKey::new(modulus, exponent)
-            }),
-        )(input)
+    pub(super) fn rsa_pubkey(
+        max_size: usize,
+    ) -> impl Fn(&[u8]) -> IResult<&[u8], rsa::RsaPublicKey> {
+        move |input| {
+            preceded(
+                string_tag(SSH_RSA_KEY_PREFIX),
+                map_res(tuple((mpint, mpint)), |(exponent, modulus)| {
+                    rsa::RsaPublicKey::new_with_max_size(modulus, exponent, max_size)
+                }),
+            )(input)
+        }
     }
 
     /// An SSH-encoded Ed25519 public key.

--- a/age/src/ssh/recipient.rs
+++ b/age/src/ssh/recipient.rs
@@ -43,6 +43,7 @@ pub enum Recipient {
 
 pub(crate) enum ParsedRecipient {
     Supported(Recipient),
+    RsaModulusTooLarge,
     Unsupported(String),
 }
 
@@ -55,6 +56,8 @@ pub enum ParseRecipientKeyError {
     Ignore,
     /// The string is not a valid SSH recipient.
     Invalid(&'static str),
+    /// The string is an ssh-rsa public key with a modulus larger than we support.
+    RsaModulusTooLarge,
     /// The string is a parseable value that corresponds to an unsupported SSH key type.
     Unsupported(String),
 }
@@ -66,6 +69,9 @@ impl std::str::FromStr for Recipient {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match ssh_recipient(rsa::RsaPublicKey::MAX_SIZE)(s) {
             Ok((_, ParsedRecipient::Supported(pk))) => Ok(pk),
+            Ok((_, ParsedRecipient::RsaModulusTooLarge)) => {
+                Err(ParseRecipientKeyError::RsaModulusTooLarge)
+            }
             Ok((_, ParsedRecipient::Unsupported(key_type))) => {
                 Err(ParseRecipientKeyError::Unsupported(key_type))
             }
@@ -106,7 +112,11 @@ impl TryFrom<Identity> for Recipient {
             | Identity::Unencrypted(UnencryptedKey::SshEd25519(ssh_key, _))
             | Identity::Encrypted(EncryptedKey { ssh_key, .. }) => {
                 if let Ok((_, pk)) = read_ssh::rsa_pubkey(rsa::RsaPublicKey::MAX_SIZE)(&ssh_key) {
-                    Ok(Recipient::SshRsa(ssh_key, pk))
+                    if let Some(pk) = pk {
+                        Ok(Recipient::SshRsa(ssh_key, pk))
+                    } else {
+                        Err(ParseRecipientKeyError::RsaModulusTooLarge)
+                    }
                 } else if let Ok((_, pk)) = read_ssh::ed25519_pubkey(&ssh_key) {
                     Ok(Recipient::SshEd25519(ssh_key, pk))
                 } else if let Ok((_, key_type)) = read_ssh::string(&ssh_key) {
@@ -191,7 +201,10 @@ fn ssh_rsa_pubkey(max_size: usize) -> impl Fn(&str) -> IResult<&str, ParsedRecip
             map_opt(
                 str_while_encoded(BASE64_STANDARD_NO_PAD),
                 |ssh_key| match read_ssh::rsa_pubkey(max_size)(&ssh_key) {
-                    Ok((_, pk)) => Some(ParsedRecipient::Supported(Recipient::SshRsa(ssh_key, pk))),
+                    Ok((_, Some(pk))) => {
+                        Some(ParsedRecipient::Supported(Recipient::SshRsa(ssh_key, pk)))
+                    }
+                    Ok((_, None)) => Some(ParsedRecipient::RsaModulusTooLarge),
                     Err(_) => None,
                 },
             ),

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -12,6 +12,10 @@ to 1.0.0 are beta releases.
 ### Changed
 - MSRV is now 1.65.0.
 
+### Fixed
+- OpenSSH private keys passed to `-i/--identity` that contain invalid public
+  keys are no longer ignored when encrypting, and instead cause an error.
+
 ## [0.9.2] - 2023-06-12
 ### Changed
 - Increased parsing speed of age file headers. For single-recipient encrypted

--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -112,6 +112,13 @@ err-enc-passphrase-without-file = File to encrypt must be passed as an argument 
 
 err-enc-plugin-name-flag = {-flag-plugin-name} can't be used with {-flag-encrypt}.
 
+err-enc-rsa-modulus-too-large =
+    RSA Modulus Too Large
+    ---------------------
+    OpenSSH supports various RSA modulus sizes, but {-rage} only supports public
+    keys of at most {$max_size} bits, to prevent a Denial of Service (DoS) condition
+    when encrypting to untrusted public keys.
+
 ## Decryption errors
 
 err-detected-powershell-corruption = It looks like this file was corrupted by PowerShell redirection.

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -32,6 +32,8 @@ pub(crate) enum EncryptError {
     PassphraseWithoutFileArgument,
     PluginNameFlag,
     #[cfg(feature = "ssh")]
+    RsaModulusTooLarge,
+    #[cfg(feature = "ssh")]
     UnsupportedKey(String, age::ssh::UnsupportedKey),
 }
 
@@ -128,6 +130,16 @@ impl fmt::Display for EncryptError {
             EncryptError::PluginNameFlag => {
                 wfl!(f, "err-enc-plugin-name-flag")
             }
+            #[cfg(feature = "ssh")]
+            EncryptError::RsaModulusTooLarge => write!(
+                f,
+                "{}",
+                fl!(
+                    crate::LANGUAGE_LOADER,
+                    "err-enc-rsa-modulus-too-large",
+                    max_size = 4096,
+                )
+            ),
             #[cfg(feature = "ssh")]
             EncryptError::UnsupportedKey(filename, k) => k.display(f, Some(filename.as_str())),
         }


### PR DESCRIPTION
Also fixes a `rage` bug where OpenSSH private keys containing invalid public keys (but otherwise valid) were being ignored during encryption instead of causing an error.