### PR TITLE
age: Wrap connections in a blast furnace

### DIFF
--- a/age/i18n/en-US/age.ftl
+++ b/age/i18n/en-US/age.ftl
@@ -59,6 +59,11 @@ rec-missing-plugin = Have you installed the plugin?
 
 err-plugin-identity = '{$plugin_name}' couldn't use an identity: {$message}
 err-plugin-recipient = '{$plugin_name}' couldn't use recipient {$recipient}: {$message}
+
+err-plugin-died = '{$plugin_name}' unexpectedly died.
+rec-plugin-died-1 = If you are developing a plugin, run with {$env_var} for more information.
+rec-plugin-died-2 = Warning: this prints private encryption key material to standard error.
+
 err-plugin-multiple = Plugin returned multiple errors:
 
 err-read-identity-encrypted-without-passphrase =


### PR DESCRIPTION
This enables us to provide a more useful error message when a plugin unexpectedly dies.

Closes str4d/rage#167.