### PR TITLE
rage: Give a better error message when a recipients file is missing

### DIFF
--- a/rage/i18n/en-US/rage.ftl
+++ b/rage/i18n/en-US/rage.ftl
@@ -138,6 +138,8 @@ err-enc-invalid-recipients-file =
 err-enc-missing-recipients = Missing recipients.
 rec-enc-missing-recipients = Did you forget to specify {-flag-recipient}?
 
+err-enc-missing-recipients-file = Recipients file not found: {$filename}
+
 err-enc-mixed-identity-passphrase = {-flag-identity} can't be used with {-flag-passphrase}.
 err-enc-mixed-recipient-passphrase = {-flag-recipient} can't be used with {-flag-passphrase}.
 err-enc-mixed-recipients-file-passphrase = {-flag-recipients-file} can't be used with {-flag-passphrase}.

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -35,6 +35,7 @@ pub(crate) enum EncryptError {
     },
     Io(io::Error),
     MissingRecipients,
+    MissingRecipientsFile(String),
     MixedIdentityAndPassphrase,
     MixedRecipientAndPassphrase,
     MixedRecipientsFileAndPassphrase,
@@ -100,6 +101,11 @@ impl fmt::Display for EncryptError {
                 wlnfl!(f, "err-enc-missing-recipients")?;
                 wfl!(f, "rec-enc-missing-recipients")
             }
+            EncryptError::MissingRecipientsFile(filename) => wfl!(
+                f,
+                "err-enc-missing-recipients-file",
+                filename = filename.as_str(),
+            ),
             EncryptError::MixedIdentityAndPassphrase => {
                 wfl!(f, "err-enc-mixed-identity-passphrase")
             }

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -151,7 +151,10 @@ fn read_recipients(
     }
 
     for arg in recipients_file_strings {
-        let f = File::open(&arg)?;
+        let f = File::open(&arg).map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => error::EncryptError::MissingRecipientsFile(arg.clone()),
+            _ => e.into(),
+        })?;
         let buf = BufReader::new(f);
         read_recipients_list(&arg, buf, &mut recipients, &mut plugin_recipients)?;
     }

--- a/rage/tests/cmd/rage/encrypt-missing-recipients-file.toml
+++ b/rage/tests/cmd/rage/encrypt-missing-recipients-file.toml
@@ -4,7 +4,7 @@ status = "failed"
 stdin = ""
 stdout = ""
 stderr = """
-Error: No such file or directory (os error 2)
+Error: Recipients file not found: foobar.txt
 
 [ Did rage not do what you expected? Could an error be more useful? ]
 [ Tell us: https://str4d.xyz/rage/report                            ]


### PR DESCRIPTION
This also fixes a test failure on Windows, which had a different OS error message than Unix for "file not found".