### PR TITLE
Downgrade to `ahash 0.8.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",


### PR DESCRIPTION
`ahash 0.8.7` is documented as having an MSRV of 1.60, but that release stopped enabling the `stdsimd` feature, as it was only used for AArch64 APIs and that usage was stabilised in 1.72. This broke compilation on Apple ARM devices.