### PR TITLE
rage: Use `LC_ALL` in CLI tests

### DIFF
--- a/rage/tests/cmd/rage-keygen/help_it.toml
+++ b/rage/tests/cmd/rage-keygen/help_it.toml
@@ -1,6 +1,6 @@
 bin.name = "rage-keygen"
 args = "--help"
-env.add.LANG = "it"
+env.add.LC_ALL = "it"
 stdout = """
 Usage: rage-keygen[EXE] [OPTIONS] [INPUT]
 

--- a/rage/tests/cmd/rage-mount/help_it.toml
+++ b/rage/tests/cmd/rage-mount/help_it.toml
@@ -1,6 +1,6 @@
 bin.name = "rage-mount"
 args = "--help"
-env.add.LANG = "it"
+env.add.LC_ALL = "it"
 stdout = """
 Usage: rage-mount[EXE] [OPTIONS] --types <TYPES> <FILENAME> <MOUNTPOINT>
 

--- a/rage/tests/cmd/rage/help_it.toml
+++ b/rage/tests/cmd/rage/help_it.toml
@@ -1,6 +1,6 @@
 bin.name = "rage"
 args = "--help"
-env.add.LANG = "it"
+env.add.LC_ALL = "it"
 stdout = """
 Usage: rage[EXE] [--encrypt] -r RECIPIENT [-i IDENTITY] [-a] [-o OUTPUT] [INPUT]
        rage[EXE] --decrypt [-i IDENTITY] [-o OUTPUT] [INPUT]


### PR DESCRIPTION
`LANG` can be overridden within `DesktopLanguageRequester`, while `LC_ALL` is treated as a universal override. My hypothesis is that macOS is setting some of the override variables, causing `LANG` to be ignored.