### PR TITLE
age: Parse identity files in a single pass

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -199,6 +199,19 @@ jobs:
           name: ${{ matrix.alice }}_${{ matrix.bob }}_${{ matrix.recipient }}_test4.age
           path: test4.age
 
+      - name: Generate a file to encrypt
+        run: echo "Test 5" > test5.txt
+      - name: Encrypt to identity in a named pipe
+        run: ./${{ matrix.alice }} -e -i <(cat key.txt) -o test.age test5.txt
+      - name: Decrypt with identity in a named pipe
+        run: ./${{ matrix.bob }} -d -i <(cat key.txt) test.age | grep -q "^Test 5$"
+      - name: Store test5.age
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ${{ matrix.alice }}_${{ matrix.bob }}_${{ matrix.recipient }}_test5.age
+          path: test5.age
+
       - name: Keygen prevents overwriting an existing file
         run: |
           touch do_not_overwrite_key.txt

--- a/age/src/primitives/armor.rs
+++ b/age/src/primitives/armor.rs
@@ -737,6 +737,14 @@ impl<R: Read> ArmoredReader<BufReader<R>> {
     }
 }
 
+#[cfg(feature = "cli-common")]
+impl<R: BufRead> ArmoredReader<R> {
+    /// Wraps a buffered reader that may contain an armored age file.
+    pub(crate) fn new_buffered(reader: R) -> Self {
+        ArmoredReader::with_buffered(reader)
+    }
+}
+
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 impl<R: AsyncRead + Unpin> ArmoredReader<AsyncBufReader<R>> {


### PR DESCRIPTION
This enables identities to be passed via named pipes, because we are no longer opening the file more than once.

Closes str4d/rage#379.