### PR TITLE
Add informations for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more plugins, implementations, tools, and integrations, check out the
 | Debian | [Debian packages](https://github.com/str4d/rage/releases) |
 | openSUSE Tumbleweed | `zypper install rage-encryption` |
 | Ubuntu 20.04+ | [Debian packages](https://github.com/str4d/rage/releases) |
+| FreeBSD | `pkg install rage-encryption` |
 
 On Windows, Linux, and macOS, you can use the
 [pre-built binaries](https://github.com/str4d/rage/releases).


### PR DESCRIPTION
A [FreeBSD port](https://github.com/freebsd/freebsd-ports/commit/9527b2227431febc7700075a76935159bd1e3b8f) is now available.

Add packaging information for FreeBSD.