### PR TITLE
rage: Revert to using requested langauges for `age` localization

### DIFF
--- a/rage/src/bin/rage-keygen/main.rs
+++ b/rage/src/bin/rage-keygen/main.rs
@@ -31,9 +31,9 @@ fn main() -> Result<(), error::Error> {
         .parse_default_env()
         .init();
 
-    let supported_languages =
-        i18n::load_languages(&DesktopLanguageRequester::requested_languages());
-    age::localizer().select(&supported_languages).unwrap();
+    let requested_languages = DesktopLanguageRequester::requested_languages();
+    i18n::load_languages(&requested_languages);
+    age::localizer().select(&requested_languages).unwrap();
 
     let opts = cli::AgeOptions::parse();
 

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -177,9 +177,9 @@ fn main() -> Result<(), Error> {
         .parse_default_env()
         .init();
 
-    let supported_languages =
-        i18n::load_languages(&DesktopLanguageRequester::requested_languages());
-    age::localizer().select(&supported_languages).unwrap();
+    let requested_languages = DesktopLanguageRequester::requested_languages();
+    i18n::load_languages(&requested_languages);
+    age::localizer().select(&requested_languages).unwrap();
 
     if console::user_attended() && args().len() == 1 {
         cli::AgeMountOptions::command().print_help()?;

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -353,9 +353,9 @@ fn main() -> Result<(), error::Error> {
         .parse_default_env()
         .init();
 
-    let supported_languages =
-        i18n::load_languages(&DesktopLanguageRequester::requested_languages());
-    age::localizer().select(&supported_languages).unwrap();
+    let requested_languages = DesktopLanguageRequester::requested_languages();
+    i18n::load_languages(&requested_languages);
+    age::localizer().select(&requested_languages).unwrap();
 
     // If you are piping input with no other args, this will not allow
     // it.


### PR DESCRIPTION
This ensures that if we have a matching locale for `age` but not `rage`, we don't ignore the `age` locale, and instead use the best match for each of them.