### PR TITLE
Update Cargo.toml

### DIFF
--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -30,7 +30,7 @@ rand.workspace = true
 rsa = { version = "0.9", default-features = false, optional = true }
 
 # - Conversion of public keys from Ed25519 to X25519
-curve25519-dalek = { version = "4", optional = true }
+curve25519-dalek = { version = "4.1.3", optional = true }
 
 # Async I/O
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)