### PR TITLE
Update to secrecy 0.10.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,9 +1823,8 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinentry"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5b8bc68be6a5e2ba84ee86db53f816cba1905b94fcb7c236e606221cc8fc8"
+version = "0.5.1"
+source = "git+https://github.com/tmpfs/pinentry-rs?branch=secrecy-0.10#793079253ea45327a1e6ee2c2b52c19fb54c431e"
 dependencies = [
  "log",
  "nom",
@@ -2325,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ cookie-factory = "0.3.1"
 nom = { version = "7", default-features = false, features = ["alloc"] }
 
 # Secret management
-pinentry = "0.5"
-secrecy = "0.8"
+pinentry = { version = "0.5", git = "https://github.com/tmpfs/pinentry-rs", branch = "secrecy-0.10"}
+secrecy = "0.10"
 subtle = "2"
 zeroize = "1"
 

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -5,7 +5,7 @@ use rand::{
     distributions::{Distribution, Uniform},
     thread_rng, RngCore,
 };
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 
 /// The prefix identifying an age stanza.
 const STANZA_TAG: &str = "-> ";
@@ -14,11 +14,11 @@ const STANZA_TAG: &str = "-> ";
 pub const FILE_KEY_BYTES: usize = 16;
 
 /// A file key for encrypting or decrypting an age file.
-pub struct FileKey(Secret<[u8; FILE_KEY_BYTES]>);
+pub struct FileKey(SecretBox<[u8; FILE_KEY_BYTES]>);
 
 impl From<[u8; FILE_KEY_BYTES]> for FileKey {
     fn from(file_key: [u8; FILE_KEY_BYTES]) -> Self {
-        FileKey(Secret::new(file_key))
+        FileKey(SecretBox::new(file_key.into()))
     }
 }
 

--- a/age-core/src/plugin.rs
+++ b/age-core/src/plugin.rs
@@ -4,7 +4,7 @@
 //! implementations built around the `age-plugin` crate.
 
 use rand::{thread_rng, Rng};
-use secrecy::Zeroize;
+use secrecy::zeroize::Zeroize;
 use std::env;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Read, Write};

--- a/age-plugin/src/identity.rs
+++ b/age-plugin/src/identity.rs
@@ -135,7 +135,7 @@ impl<'a, 'b, R: io::Read, W: io::Write> Callbacks<Error> for BidirCallbacks<'a, 
             .and_then(|res| match res {
                 Ok(s) => String::from_utf8(s.body)
                     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "secret is not UTF-8"))
-                    .map(|s| Ok(SecretString::new(s))),
+                    .map(|s| Ok(s.into())),
                 Err(e) => Ok(Err(e)),
             })
     }

--- a/age-plugin/src/recipient.rs
+++ b/age-plugin/src/recipient.rs
@@ -183,7 +183,7 @@ impl<'a, 'b, R: io::Read, W: io::Write> Callbacks<Error> for BidirCallbacks<'a, 
             .and_then(|res| match res {
                 Ok(s) => String::from_utf8(s.body)
                     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "secret is not UTF-8"))
-                    .map(|s| Ok(SecretString::new(s))),
+                    .map(|s| Ok(s.into())),
                 Err(e) => Ok(Err(e)),
             })
     }

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -37,7 +37,7 @@ futures = { version = "0.3", optional = true }
 pin-project = "1"
 
 # Common CLI dependencies
-pinentry = { version = "0.5", optional = true }
+pinentry = { version = "0.5", git = "https://github.com/tmpfs/pinentry-rs", branch = "secrecy-0.10", optional = true}
 
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -125,10 +125,10 @@ pub fn read_secret(
         input.interact()
     } else {
         // Fall back to CLI interface.
-        let passphrase = prompt_password(format!("{}: ", description)).map(SecretString::new)?;
+        let passphrase = prompt_password(format!("{}: ", description)).map(SecretString::from)?;
         if let Some(confirm_prompt) = confirm {
             let confirm_passphrase =
-                prompt_password(format!("{}: ", confirm_prompt)).map(SecretString::new)?;
+                prompt_password(format!("{}: ", confirm_prompt)).map(SecretString::from)?;
 
             if !bool::from(
                 passphrase
@@ -199,7 +199,7 @@ impl Passphrase {
                     acc + "-" + s
                 }
             });
-        Passphrase::Generated(SecretString::new(new_passphrase))
+        Passphrase::Generated(new_passphrase.into())
     }
 }
 

--- a/age/src/encrypted.rs
+++ b/age/src/encrypted.rs
@@ -239,9 +239,7 @@ fOrxrKTj7xCdNS3+OrCdnBC8Z9cKDxjCGWW3fkjLsYha0Jo=
 
         /// This intentionally panics if called twice.
         fn request_passphrase(&self, _: &str) -> Option<SecretString> {
-            Some(SecretString::new(
-                self.0.lock().unwrap().take().unwrap().to_owned(),
-            ))
+            Some(self.0.lock().unwrap().take().unwrap().to_owned().into())
         }
     }
 

--- a/age/src/keys.rs
+++ b/age/src/keys.rs
@@ -3,7 +3,7 @@
 use age_core::{
     format::FileKey,
     primitives::hkdf,
-    secrecy::{ExposeSecret, Secret},
+    secrecy::{ExposeSecret, SecretBox},
 };
 use rand::{rngs::OsRng, RngCore};
 
@@ -24,11 +24,9 @@ pub(crate) fn new_file_key() -> FileKey {
 }
 
 pub(crate) fn mac_key(file_key: &FileKey) -> HmacKey {
-    HmacKey(Secret::new(hkdf(
-        &[],
-        HEADER_KEY_LABEL,
-        file_key.expose_secret(),
-    )))
+    HmacKey(SecretBox::new(
+        hkdf(&[], HEADER_KEY_LABEL, file_key.expose_secret()).into(),
+    ))
 }
 
 pub(crate) fn v1_payload_key(

--- a/age/src/primitives.rs
+++ b/age/src/primitives.rs
@@ -1,6 +1,6 @@
 //! Primitive cryptographic operations used by `age`.
 
-use age_core::secrecy::{ExposeSecret, Secret};
+use age_core::secrecy::{ExposeSecret, SecretBox};
 use hmac::{
     digest::{CtOutput, MacError},
     Hmac, Mac,
@@ -15,7 +15,7 @@ pub mod armor;
 
 pub mod stream;
 
-pub(crate) struct HmacKey(pub(crate) Secret<[u8; 32]>);
+pub(crate) struct HmacKey(pub(crate) SecretBox<[u8; 32]>);
 
 /// `HMAC[key](message)`
 ///

--- a/age/src/primitives/stream.rs
+++ b/age/src/primitives/stream.rs
@@ -1,6 +1,6 @@
 //! I/O helper structs for age file encryption and decryption.
 
-use age_core::secrecy::{ExposeSecret, SecretVec};
+use age_core::secrecy::{ExposeSecret, SecretBox};
 use chacha20poly1305::{
     aead::{generic_array::GenericArray, Aead, KeyInit, KeySizeUser},
     ChaCha20Poly1305,
@@ -194,7 +194,7 @@ impl Stream {
         Ok(encrypted)
     }
 
-    fn decrypt_chunk(&mut self, chunk: &[u8], last: bool) -> io::Result<SecretVec<u8>> {
+    fn decrypt_chunk(&mut self, chunk: &[u8], last: bool) -> io::Result<SecretBox<[u8]>> {
         assert!(chunk.len() <= ENCRYPTED_CHUNK_SIZE);
 
         self.nonce.set_last(last).map_err(|_| {
@@ -204,8 +204,9 @@ impl Stream {
         let decrypted = self
             .aead
             .decrypt(&self.nonce.to_bytes().into(), chunk)
-            .map(SecretVec::new)
+            .map(SecretBox::from)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "decryption error"))?;
+
         self.nonce.increment_counter();
 
         Ok(decrypted)
@@ -407,7 +408,7 @@ pub struct StreamReader<R> {
     start: StartPos,
     plaintext_len: Option<u64>,
     cur_plaintext_pos: u64,
-    chunk: Option<SecretVec<u8>>,
+    chunk: Option<SecretBox<[u8]>>,
 }
 
 impl<R> StreamReader<R> {

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -335,8 +335,6 @@ mod tests {
     use std::collections::HashSet;
     use std::io::{BufReader, Read, Write};
 
-    use age_core::secrecy::SecretString;
-
     #[cfg(feature = "ssh")]
     use std::iter;
 
@@ -477,7 +475,7 @@ mod tests {
     fn scrypt_round_trip() {
         let test_msg = b"This is a test message. For testing.";
 
-        let mut recipient = scrypt::Recipient::new(SecretString::new("passphrase".to_string()));
+        let mut recipient = scrypt::Recipient::new("passphrase".to_string().into());
         // Override to something very fast for testing.
         recipient.set_work_factor(2);
 
@@ -491,10 +489,7 @@ mod tests {
 
         let d = Decryptor::new(&encrypted[..]).unwrap();
         let mut r = d
-            .decrypt(
-                Some(&scrypt::Identity::new(SecretString::new("passphrase".to_string())) as _)
-                    .into_iter(),
-            )
+            .decrypt(Some(&scrypt::Identity::new("passphrase".to_string().into()) as _).into_iter())
             .unwrap();
         let mut decrypted = vec![];
         r.read_to_end(&mut decrypted).unwrap();
@@ -549,7 +544,7 @@ mod tests {
     #[test]
     fn mixed_recipient_and_passphrase() {
         let pk: x25519::Recipient = crate::x25519::tests::TEST_PK.parse().unwrap();
-        let passphrase = crate::scrypt::Recipient::new(SecretString::new("passphrase".to_string()));
+        let passphrase = crate::scrypt::Recipient::new("passphrase".to_string().into());
 
         let recipients = [&pk as &dyn Recipient, &passphrase as _];
 

--- a/age/src/ssh.rs
+++ b/age/src/ssh.rs
@@ -194,7 +194,7 @@ mod decrypt {
 }
 
 mod read_ssh {
-    use age_core::secrecy::Secret;
+    use age_core::secrecy::SecretBox;
     use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
     use nom::{
         branch::alt,
@@ -349,14 +349,14 @@ mod read_ssh {
     /// Internal OpenSSH encoding of an Ed25519 private key.
     ///
     /// - [OpenSSH serialization code](https://github.com/openssh/openssh-portable/blob/4103a3ec7c68493dbc4f0994a229507e943a86d3/sshkey.c#L3277-L3283)
-    fn openssh_ed25519_privkey(input: &[u8]) -> IResult<&[u8], Secret<[u8; 64]>> {
+    fn openssh_ed25519_privkey(input: &[u8]) -> IResult<&[u8], SecretBox<[u8; 64]>> {
         delimited(
             string_tag(SSH_ED25519_KEY_PREFIX),
             map_opt(tuple((string, string)), |(pubkey_bytes, privkey_bytes)| {
                 if privkey_bytes.len() == 64 && pubkey_bytes == &privkey_bytes[32..64] {
                     let mut privkey = [0; 64];
                     privkey.copy_from_slice(privkey_bytes);
-                    Some(Secret::new(privkey))
+                    Some(SecretBox::new(privkey.into()))
                 } else {
                     None
                 }

--- a/age/src/x25519.rs
+++ b/age/src/x25519.rs
@@ -68,7 +68,7 @@ impl Identity {
         let sk_base32 = sk_bytes.to_base32();
         let mut encoded =
             bech32::encode(SECRET_KEY_PREFIX, sk_base32, Variant::Bech32).expect("HRP is valid");
-        let ret = SecretString::new(encoded.to_uppercase());
+        let ret = encoded.to_uppercase().into();
 
         // Clear intermediates
         sk_bytes.zeroize();

--- a/age/tests/test_vectors.rs
+++ b/age/tests/test_vectors.rs
@@ -44,7 +44,7 @@ fn age_test_vectors() -> Result<(), Box<dyn std::error::Error>> {
                 name
             ))?
             .read_to_string(&mut passphrase)?;
-            let passphrase = SecretString::new(passphrase);
+            let passphrase: SecretString = passphrase.into();
             let identity = scrypt::Identity::new(passphrase);
             d.decrypt(Some(&identity as _).into_iter())
         };


### PR DESCRIPTION
Requires pointing to a git dependency of `pinentry` for now which also needs updating.

One test (`gen-stdout.toml`) is failing using `cargo +stable test` but it also fails on `main` so I don't think it was introduced by these changes.

@str4d, if we can get a new version of `pinentry` published I can update the PR to remove the git dependency.