### PR TITLE
Fix default features test compilation error

### DIFF
--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -334,11 +334,9 @@ impl<R: AsyncBufRead + Unpin> Decryptor<R> {
 mod tests {
     use std::collections::HashSet;
     use std::io::{BufReader, Read, Write};
+    use std::iter;
 
     use age_core::secrecy::SecretString;
-
-    #[cfg(feature = "ssh")]
-    use std::iter;
 
     use super::{Decryptor, Encryptor};
     use crate::{identity::IdentityFile, scrypt, x25519, EncryptError, Identity, Recipient};


### PR DESCRIPTION
`std::iter` is used by some tests not gated by `#[cfg(feature = "ssh")]`

Before this change, `cargo build --tests` fails when run in the `age` package. (It does work when run from the root workspace; I don't have enough experience to understand the discrepancy.)