### PR TITLE
fix: replace assert with error handling for stanza count mismatch

### DIFF
--- a/age-plugin/src/recipient.rs
+++ b/age-plugin/src/recipient.rs
@@ -450,7 +450,17 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
                     // The plugin MUST generate an error if one or more recipients or
                     // identities cannot be wrapped to. And it's a programming error
                     // to return more stanzas than recipients and identities.
-                    assert_eq!(stanzas.len(), expected_stanzas);
+                    if stanzas.len() != expected_stanzas {
+                        Error::Internal {
+                            message: format!(
+                                "Plugin returned {} stanzas but expected {}",
+                                stanzas.len(),
+                                expected_stanzas
+                            ),
+                        }
+                        .send(&mut phase)?;
+                        return Ok(());
+                    }
 
                     for stanza in stanzas {
                         phase


### PR DESCRIPTION
Replaces the panic-prone `assert_eq!(stanzas.len(), expected_stanzas)` with proper handling that:

  1. Checks if the stanza count matches the expected count.
  2. If there's a mismatch, creates a `recipient::Error::Internal` with a descriptive message.
  3. Sends the error via the IPC channel using `.send(&mut phase)?`.
  4. Returns gracefully instead of crashing.
  
  Closes #576 