### PR TITLE
feat(age): add BIP39 mnemonic support for Identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "base64",
  "bcrypt-pbkdf",
  "bech32",
+ "bip39",
  "cbc",
  "chacha20poly1305",
  "cipher",
@@ -299,6 +300,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bip39"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57d9ec48ba4428714015aa2e68846444f254380d9fe1cd4266d3a4635019d83"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +324,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -1187,6 +1208,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hkdf"
@@ -2690,6 +2720,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,6 +2849,15 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "universal-hash"

--- a/age/Cargo.toml
+++ b/age/Cargo.toml
@@ -20,6 +20,7 @@ age-core.workspace = true
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
 base64.workspace = true
+bip39 = { version = "2.0.0", optional = true }
 chacha20poly1305.workspace = true
 hmac.workspace = true
 i18n-embed.workspace = true
@@ -114,6 +115,7 @@ ssh = [
     "rsa",
 ]
 unstable = ["age-core/unstable"]
+bip39 = ["dep:bip39"]
 
 [lib]
 bench = false


### PR DESCRIPTION

## Summary
This PR introduces support for BIP39 mnemonics to the `age` crate, enabling users to backup and restore `x25519::Identity` using a 24-word phrase. This facilitates deterministic key generation and easier key management.

## Changes

### `age` Crate
- **Added `Identity::from_secret_bytes`**: A public method to construct an `Identity` from a raw 32-byte array.
    - *Note*: Added a strong `# Security` section to the documentation warning users to only provide high-entropy inputs (CSPRNG or KDF derived).
- **Added `bip39` Feature**:
    - Introduced an optional dependency on `bip39` (v2.0).
    - Added a `bip39` feature flag to `Cargo.toml`.
- **BIP39 Implementation**:
    - Implemented `Identity::to_mnemonic(&self) -> Mnemonic`: Serializes the secret key into a 24-word English mnemonic.
    - Implemented `Identity::from_mnemonic(&Mnemonic) -> Result<Self, &'static str>`: Restores an identity from a mnemonic.
    - **Security**: Intermediate entropy vectors are explicitly zeroized using the `Zeroize` trait before being dropped.

## Testing
- Added unit tests for the new functionality:
    - `identity_from_secret_bytes`: Verifies raw byte deserialization.
    - `mnemonic_round_trip`: Verifies that an identity can be converted to a mnemonic and restored back correctly (guarded by `bip39` feature).
    - `invalid_mnemonic_length`: Ensures that mnemonics with insufficient entropy (e.g., 12 words/128 bits) are rejected safely.

## Verification
Run the tests including the new feature:
```bash
cargo test --package age --lib --features bip39
```
