### PR TITLE
age-core: Add Bech32 helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ name = "age-core"
 version = "0.11.0"
 dependencies = [
  "base64",
+ "bech32",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",

--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -8,6 +8,12 @@ to 1.0.0 are beta releases.
 
 ## [Unreleased]
 
+### Added
+- `age_core::primitives`:
+  - `bech32_encode`
+  - `bech32_encode_to_fmt`
+  - `bech32_decode`
+
 ### Changed
 - MSRV is now 1.70.0.
 

--- a/age-core/Cargo.toml
+++ b/age-core/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
+bech32.workspace = true
 chacha20poly1305.workspace = true
 cookie-factory.workspace = true
 io_tee = "0.1.1"

--- a/age/src/util.rs
+++ b/age/src/util.rs
@@ -1,15 +1,7 @@
-use bech32::{primitives::decode::CheckedHrpstring, Bech32};
-
 #[cfg(all(any(feature = "armor", feature = "cli-common"), windows))]
 pub(crate) const LINE_ENDING: &str = "\r\n";
 #[cfg(all(any(feature = "armor", feature = "cli-common"), not(windows)))]
 pub(crate) const LINE_ENDING: &str = "\n";
-
-pub(crate) fn parse_bech32(s: &str) -> Option<(String, Vec<u8>)> {
-    CheckedHrpstring::new::<Bech32>(s)
-        .ok()
-        .map(|parsed| (parsed.hrp().as_str().into(), parsed.byte_iter().collect()))
-}
 
 pub(crate) mod read {
     use std::str::FromStr;


### PR DESCRIPTION
These implement the correct-for-age behaviour of ignoring Bech32 length limits.