### PR TITLE
age: Replace HashSet with BTreeSet for deterministic iteration

### DIFF
--- a/age/src/error.rs
+++ b/age/src/error.rs
@@ -1,6 +1,6 @@
 //! Error type.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::io;
 
@@ -173,15 +173,15 @@ pub enum EncryptError {
     /// The encryptor was given recipients that declare themselves incompatible.
     IncompatibleRecipients {
         /// The set of labels from the first recipient provided to the encryptor.
-        l_labels: HashSet<String>,
+        l_labels: BTreeSet<String>,
         /// The set of labels from the first non-matching recipient.
-        r_labels: HashSet<String>,
+        r_labels: BTreeSet<String>,
     },
     /// One or more of the labels from the first recipient provided to the encryptor are
     /// invalid.
     ///
     /// Labels must be valid age "arbitrary string"s (`1*VCHAR` in ABNF).
-    InvalidRecipientLabels(HashSet<String>),
+    InvalidRecipientLabels(BTreeSet<String>),
     /// An I/O error occurred during encryption.
     Io(io::Error),
     /// The encryptor was not given any recipients.
@@ -226,7 +226,7 @@ impl Clone for EncryptError {
     }
 }
 
-fn print_labels(labels: &HashSet<String>) -> String {
+fn print_labels(labels: &BTreeSet<String>) -> String {
     let mut s = String::new();
     for (i, label) in labels.iter().enumerate() {
         s.push_str(label);

--- a/age/src/lib.rs
+++ b/age/src/lib.rs
@@ -208,7 +208,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 // Re-export crates that are used in our public API.
 pub use age_core::secrecy;
@@ -372,7 +372,7 @@ pub trait Recipient {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError>;
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError>;
 }
 
 /// Callbacks that might be triggered during encryption or decryption.

--- a/age/src/native.rs
+++ b/age/src/native.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use hkdf::Hkdf;
 use sha2::{Digest, Sha256};
@@ -20,6 +20,6 @@ fn stanza_tag(ikm: &[u8], salt: &str) -> [u8; 4] {
     tag[..4].try_into().expect("correct length")
 }
 
-fn label_pq_only() -> HashSet<String> {
+fn label_pq_only() -> BTreeSet<String> {
     ["postquantum".into()].into_iter().collect()
 }

--- a/age/src/native/scrypt.rs
+++ b/age/src/native/scrypt.rs
@@ -1,6 +1,6 @@
 //! The "scrypt" passphrase-based recipient type, native to age.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::iter;
 use std::time::Duration;
 
@@ -138,7 +138,7 @@ impl crate::Recipient for Recipient {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError> {
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError> {
         let mut rng = OsRng;
 
         let mut salt = [0; SALT_LEN];

--- a/age/src/native/tag.rs
+++ b/age/src/native/tag.rs
@@ -1,6 +1,6 @@
 //! The "tag" recipient type, native to age.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 
 use age_core::{
@@ -91,7 +91,7 @@ impl crate::Recipient for Recipient {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError> {
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError> {
         let (enc, ct) = hpke_seal::<Kem, _>(
             &self.pk_recip,
             P256TAG_SALT.as_bytes(),
@@ -115,7 +115,7 @@ impl crate::Recipient for Recipient {
                 args: vec![encoded_tag, encoded_enc],
                 body: ct,
             }],
-            HashSet::new(),
+            BTreeSet::new(),
         ))
     }
 }

--- a/age/src/native/tagpq.rs
+++ b/age/src/native/tagpq.rs
@@ -1,6 +1,6 @@
 //! The "tagpq" recipient type, native to age.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 
 use age_core::{
@@ -91,7 +91,7 @@ impl crate::Recipient for Recipient {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError> {
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError> {
         let (enc, ct) = hpke_seal::<Kem, _>(
             &self.0,
             MLKEM768P256TAG_SALT.as_bytes(),

--- a/age/src/native/x25519.rs
+++ b/age/src/native/x25519.rs
@@ -1,6 +1,6 @@
 //! The classic recipient type, native to age.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 
 use age_core::{
@@ -192,7 +192,7 @@ impl crate::Recipient for Recipient {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError> {
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError> {
         let rng = OsRng;
         let esk = EphemeralSecret::random_from_rng(rng);
         let epk: PublicKey = (&esk).into();
@@ -227,7 +227,7 @@ impl crate::Recipient for Recipient {
                 args: vec![encoded_epk],
                 body: encrypted_file_key,
             }],
-            HashSet::new(),
+            BTreeSet::new(),
         ))
     }
 }

--- a/age/src/plugin.rs
+++ b/age/src/plugin.rs
@@ -11,7 +11,7 @@ use base64::{prelude::BASE64_STANDARD_NO_PAD, Engine};
 use bech32::Hrp;
 
 use std::borrow::Borrow;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::io;
 use std::iter;
@@ -414,7 +414,7 @@ impl<C: Callbacks> crate::Recipient for RecipientPluginV1<C> {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError> {
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError> {
         // Open connection
         let mut conn = self.plugin.connect(RECIPIENT_V1)?;
 
@@ -502,7 +502,7 @@ impl<C: Callbacks> crate::Recipient for RecipientPluginV1<C> {
                 CMD_LABELS => {
                     if labels.is_none() {
                         let labels_count = command.args.len();
-                        let label_set = command.args.into_iter().collect::<HashSet<_>>();
+                        let label_set = command.args.into_iter().collect::<BTreeSet<_>>();
                         if label_set.len() == labels_count {
                             labels = Some(label_set);
                         } else {

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -332,7 +332,7 @@ impl<R: AsyncBufRead + Unpin> Decryptor<R> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
     use std::io::{BufReader, Read, Write};
     use std::iter;
 
@@ -558,7 +558,7 @@ mod tests {
         fn wrap_file_key(
             &self,
             file_key: &age_core::format::FileKey,
-        ) -> Result<(Vec<age_core::format::Stanza>, HashSet<String>), EncryptError> {
+        ) -> Result<(Vec<age_core::format::Stanza>, BTreeSet<String>), EncryptError> {
             self.0.wrap_file_key(file_key).map(|(stanzas, mut labels)| {
                 labels.insert("incompatible".into());
                 (stanzas, labels)

--- a/age/src/ssh/recipient.rs
+++ b/age/src/ssh/recipient.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 
 use age_core::{
@@ -150,7 +150,7 @@ impl crate::Recipient for Recipient {
     fn wrap_file_key(
         &self,
         file_key: &FileKey,
-    ) -> Result<(Vec<Stanza>, HashSet<String>), EncryptError> {
+    ) -> Result<(Vec<Stanza>, BTreeSet<String>), EncryptError> {
         let mut rng = OsRng;
 
         let stanzas = match self {
@@ -204,7 +204,7 @@ impl crate::Recipient for Recipient {
             }
         };
 
-        Ok((stanzas, HashSet::new()))
+        Ok((stanzas, BTreeSet::new()))
     }
 }
 


### PR DESCRIPTION
This change is to remove a source of nondeterminism in age's label handling.

In downstream reproducible-build testing, we were seeing otherwise-identical builds produce different `zcash-devtool` binaries. 

`diffoscope` narrowed that down to code generation differences in `age::error::PluginError::fmt`, which pointed back to non-deterministic iteration order from `HashSet`-backed label metadata. Switching these paths to `BTreeSet` makes the iteration order deterministic.

I tested this by pointing `zcash-devtool` at a local checkout of this branch and rebuilding with the patched age crate.