### PR TITLE
Fix Italian language unit tests

### DIFF
--- a/rage/tests/unix_not_apple_android/rage-keygen/help_it.toml
+++ b/rage/tests/unix_not_apple_android/rage-keygen/help_it.toml
@@ -1,5 +1,6 @@
 bin.name = "rage-keygen"
 args = "--help"
+env.add.LANGUAGE = "it"
 env.add.LC_ALL = "it"
 stdout = """
 Utilizzo: rage-keygen[EXE] [OPTIONS] [INPUT]

--- a/rage/tests/unix_not_apple_android/rage-mount/help_it.toml
+++ b/rage/tests/unix_not_apple_android/rage-mount/help_it.toml
@@ -1,5 +1,6 @@
 bin.name = "rage-mount"
 args = "--help"
+env.add.LANGUAGE = "it"
 env.add.LC_ALL = "it"
 stdout = """
 Utilizzo: rage-mount[EXE] [OPTIONS] --types <TIPI> <PERCORSO> <MOUNTPOINT>

--- a/rage/tests/unix_not_apple_android/rage/help_it.toml
+++ b/rage/tests/unix_not_apple_android/rage/help_it.toml
@@ -1,5 +1,6 @@
 bin.name = "rage"
 args = "--help"
+env.add.LANGUAGE = "it"
 env.add.LC_ALL = "it"
 stdout = """
 Utilizzo: rage[EXE] [--encrypt] (-r DESTINATARIO | -R PERCORSO)... [-i IDENTITÀ] [-a] [-o OUTPUT] [INPUT]


### PR DESCRIPTION
On an Arch Linux system, setting LC_ALL in the unit tests to override the language to Italian was insufficient. I also had to set the LANGUAGE variable.