### PR TITLE
Bump MSRV to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.88"
 repository = "https://github.com/str4d/rage"
 license = "MIT OR Apache-2.0"
 
@@ -79,5 +79,4 @@ env_logger = "0.10"
 log = "0.4"
 
 [workspace.lints.rust]
-# Requires MSRV 1.80
-#unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more plugins, implementations, tools, and integrations, check out the
 
 | Environment | CLI command |
 |-------------|-------------|
-| Cargo (Rust 1.74+) | `cargo install rage` |
+| Cargo (Rust 1.88+) | `cargo install rage` |
 | Homebrew (macOS or Linux) | `brew install rage` |
 | MacPorts | `port install rage` |
 | Alpine Linux (edge) | `apk add rage` |

--- a/age-core/CHANGELOG.md
+++ b/age-core/CHANGELOG.md
@@ -17,7 +17,7 @@ to 1.0.0 are beta releases.
   - `hpke_open`
 
 ### Changed
-- MSRV is now 1.74.0.
+- MSRV is now 1.88.0.
 
 ## [0.11.0] - 2024-11-03
 ### Added

--- a/age-core/src/format.rs
+++ b/age-core/src/format.rs
@@ -523,7 +523,7 @@ xD7o4VEOu1t7KZQ1gDgq2FPzBEeSRqbnqvQEXdLRYy143BxR6oFxsUUJCRB0ErXA
         // should reject this artifact.
         match read::age_stanza(artifact.as_bytes()) {
             Err(nom::Err::Error(e)) => assert_eq!(e.code, ErrorKind::TakeWhileMN),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
             Ok((rest, stanza)) => {
                 assert_eq!(rest, b"\n");
                 // This is where the fuzzer triggered a panic.
@@ -560,7 +560,7 @@ dy
         // should reject this artifact.
         match read::age_stanza(artifact.as_bytes()) {
             Err(nom::Err::Error(e)) => assert_eq!(e.code, ErrorKind::TakeWhileMN),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
             Ok((rest, stanza)) => {
                 assert_eq!(rest, b"\n");
                 // This is where the fuzzer triggered a panic.
@@ -596,7 +596,7 @@ ddd
         // should reject this artifact.
         match read::age_stanza(artifact.as_bytes()) {
             Err(nom::Err::Error(e)) => assert_eq!(e.code, ErrorKind::TakeWhileMN),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
             Ok((rest, stanza)) => {
                 assert_eq!(rest, b"\n");
                 // This is where the fuzzer triggered a panic.

--- a/age-core/src/plugin.rs
+++ b/age-core/src/plugin.rs
@@ -76,7 +76,7 @@ impl Connection<DebugReader<ChildStdout>, DebugWriter<ChildStdin>> {
         let working_dir = tempfile::tempdir()?;
         let debug_enabled = env::var("AGEDEBUG").map(|s| s == "plugin").unwrap_or(false);
         let process = Command::new(binary.canonicalize()?)
-            .arg(format!("--age-plugin={}", state_machine))
+            .arg(format!("--age-plugin={state_machine}"))
             .current_dir(working_dir.path())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -124,7 +124,7 @@ impl<R: Read, W: Write> Connection<R, W> {
         cookie_factory::gen_simple(write::age_stanza(command, metadata, data), &mut self.output)
             .map_err(|e| match e {
                 GenError::IoError(e) => e,
-                e => io::Error::new(io::ErrorKind::Other, format!("{}", e)),
+                e => io::Error::other(format!("{e}")),
             })
             .and_then(|w| w.flush())
     }
@@ -356,7 +356,7 @@ impl<'a, R: Read, W: Write> BidirSend<'a, R, W> {
             RESPONSE_UNSUPPORTED => Ok(Err(Error::Unsupported)),
             tag => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("unexpected response: {}", tag),
+                format!("unexpected response: {tag}"),
             )),
         }
     }
@@ -380,7 +380,7 @@ impl<'a, R: Read, W: Write> BidirSend<'a, R, W> {
             RESPONSE_UNSUPPORTED => Ok(Err(Error::Unsupported)),
             tag => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("unexpected response: {}", tag),
+                format!("unexpected response: {tag}"),
             )),
         }
     }

--- a/age-plugin/CHANGELOG.md
+++ b/age-plugin/CHANGELOG.md
@@ -11,7 +11,7 @@ to 1.0.0 are beta releases.
 ## [Unreleased]
 
 ### Changed
-- MSRV is now 1.74.0.
+- MSRV is now 1.88.0.
 
 ## [0.6.1] - 2025-12-07
 ### Changed

--- a/age-plugin/examples/age-plugin-unencrypted.rs
+++ b/age-plugin/examples/age-plugin-unencrypted.rs
@@ -21,7 +21,7 @@ const RECIPIENT_TAG: &str = PLUGIN_NAME;
 fn explode(location: &str) {
     if let Ok(s) = env::var("AGE_EXPLODES") {
         if s == location {
-            panic!("Env variable AGE_EXPLODES={} is set. Boom! 💥", location);
+            panic!("Env variable AGE_EXPLODES={location} is set. Boom! 💥");
         }
     }
 }

--- a/age-plugin/src/identity.rs
+++ b/age-plugin/src/identity.rs
@@ -227,8 +227,7 @@ pub(crate) fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
                 ([identity], []) => Ok(identity.clone()),
                 _ => Err(Error::Internal {
                     message: format!(
-                        "{} command must have exactly one metadata argument and no data",
-                        ADD_IDENTITY
+                        "{ADD_IDENTITY} command must have exactly one metadata argument and no data"
                     ),
                 }),
             }),
@@ -241,15 +240,13 @@ pub(crate) fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
                         .map(|i| (i, s))
                         .map_err(|_| Error::Internal {
                             message: format!(
-                                "first metadata argument to {} must be an integer",
-                                RECIPIENT_STANZA
+                                "first metadata argument to {RECIPIENT_STANZA} must be an integer"
                             ),
                         })
                 } else {
                     Err(Error::Internal {
                         message: format!(
-                            "{} command must have at least two metadata arguments",
-                            RECIPIENT_STANZA
+                            "{RECIPIENT_STANZA} command must have at least two metadata arguments"
                         ),
                     })
                 }
@@ -313,8 +310,7 @@ pub(crate) fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
                 } else {
                     errors.push(Error::Internal {
                         message: format!(
-                            "{} file indices are not ordered and monotonically increasing",
-                            RECIPIENT_STANZA
+                            "{RECIPIENT_STANZA} file indices are not ordered and monotonically increasing"
                         ),
                     });
                 }
@@ -355,7 +351,7 @@ pub(crate) fn run_v1<P: IdentityPluginV1>(mut plugin: P) -> io::Result<()> {
                     phase
                         .send(
                             "file-key",
-                            &[&format!("{}", file_index)],
+                            &[&format!("{file_index}")],
                             file_key.expose_secret(),
                         )?
                         .unwrap();

--- a/age-plugin/src/lib.rs
+++ b/age-plugin/src/lib.rs
@@ -197,7 +197,7 @@ const PLUGIN_IDENTITY_PREFIX: &str = "AGE-PLUGIN-";
 /// A "created" time is included in the output, set to the current local time.
 pub fn print_new_identity(plugin_name: &str, identity: &[u8], recipient: &[u8]) {
     let mut identity_lower = bech32_encode(
-        Hrp::parse_unchecked(&format!("{}{}-", PLUGIN_IDENTITY_PREFIX, plugin_name)),
+        Hrp::parse_unchecked(&format!("{PLUGIN_IDENTITY_PREFIX}{plugin_name}-")),
         identity,
     );
 
@@ -208,7 +208,7 @@ pub fn print_new_identity(plugin_name: &str, identity: &[u8], recipient: &[u8]) 
     println!(
         "# recipient: {}",
         bech32_encode(
-            Hrp::parse_unchecked(&format!("{}{}", PLUGIN_RECIPIENT_PREFIX, plugin_name)),
+            Hrp::parse_unchecked(&format!("{PLUGIN_RECIPIENT_PREFIX}{plugin_name}")),
             recipient,
         )
     );

--- a/age-plugin/src/recipient.rs
+++ b/age-plugin/src/recipient.rs
@@ -269,8 +269,7 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
                 ([recipient], []) => Ok(recipient.clone()),
                 _ => Err(Error::Internal {
                     message: format!(
-                        "{} command must have exactly one metadata argument and no data",
-                        ADD_RECIPIENT
+                        "{ADD_RECIPIENT} command must have exactly one metadata argument and no data"
                     ),
                 }),
             }),
@@ -278,8 +277,7 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
                 ([identity], []) => Ok(identity.clone()),
                 _ => Err(Error::Internal {
                     message: format!(
-                        "{} command must have exactly one metadata argument and no data",
-                        ADD_IDENTITY
+                        "{ADD_IDENTITY} command must have exactly one metadata argument and no data"
                     ),
                 }),
             }),
@@ -303,8 +301,7 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
                 (Ok(r), Ok(i)) if r.is_empty() && i.is_empty() => (
                     Err(vec![Error::Internal {
                         message: format!(
-                            "Need at least one {} or {} command",
-                            ADD_RECIPIENT, ADD_IDENTITY
+                            "Need at least one {ADD_RECIPIENT} or {ADD_IDENTITY} command"
                         ),
                     }]),
                     Err(vec![]),
@@ -313,7 +310,7 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
             },
             match file_keys.unwrap() {
                 Ok(f) if f.is_empty() => Err(vec![Error::Internal {
-                    message: format!("Need at least one {} command", WRAP_FILE_KEY),
+                    message: format!("Need at least one {WRAP_FILE_KEY} command"),
                 }]),
                 r => r,
             },
@@ -321,7 +318,7 @@ pub(crate) fn run_v1<P: RecipientPluginV1>(mut plugin: P) -> io::Result<()> {
                 Ok(v) if v.is_empty() => Ok(false),
                 Ok(v) if v.len() == 1 => Ok(true),
                 _ => Err(vec![Error::Internal {
-                    message: format!("Received more than one {} command", EXTENSION_LABELS),
+                    message: format!("Received more than one {EXTENSION_LABELS} command"),
                 }]),
             },
         )

--- a/age/CHANGELOG.md
+++ b/age/CHANGELOG.md
@@ -17,7 +17,7 @@ to 1.0.0 are beta releases.
 - `age::plugin::ResolveError`
 
 ### Changed
-- MSRV is now 1.74.0.
+- MSRV is now 1.88.0.
 - Migrated to `base64 0.22`, `i18n-embed 0.16`.
 - `age::IdentityFile::into_identities` now returns
   `Result<Vec<Box<dyn crate::Identity + Send + Sync>>, DecryptError>` instead of

--- a/age/src/cli_common.rs
+++ b/age/src/cli_common.rs
@@ -66,7 +66,7 @@ fn confirm(query: &str, ok: &str, cancel: Option<&str>) -> pinentry::Result<bool
     } else {
         // Fall back to CLI interface.
         let term = console::Term::stderr();
-        let initial = format!("{}: (y/n) ", query);
+        let initial = format!("{query}: (y/n) ");
         loop {
             term.write_str(&initial)?;
             let response = term.read_line()?.to_lowercase();
@@ -125,10 +125,10 @@ pub fn read_secret(
         input.interact()
     } else {
         // Fall back to CLI interface.
-        let passphrase = prompt_password(format!("{}: ", description)).map(SecretString::from)?;
+        let passphrase = prompt_password(format!("{description}: ")).map(SecretString::from)?;
         if let Some(confirm_prompt) = confirm {
             let confirm_passphrase =
-                prompt_password(format!("{}: ", confirm_prompt)).map(SecretString::from)?;
+                prompt_password(format!("{confirm_prompt}: ")).map(SecretString::from)?;
 
             if !bool::from(
                 passphrase
@@ -155,7 +155,7 @@ pub struct UiCallbacks;
 
 impl Callbacks for UiCallbacks {
     fn display_message(&self, message: &str) {
-        eprintln!("{}", message);
+        eprintln!("{message}");
     }
 
     fn confirm(&self, message: &str, yes_string: &str, no_string: Option<&str>) -> Option<bool> {

--- a/age/src/cli_common/error.rs
+++ b/age/src/cli_common/error.rs
@@ -83,7 +83,7 @@ impl fmt::Display for ReadError {
                 filename = filename.as_str(),
                 line_number = line_number,
             ),
-            ReadError::Io(e) => write!(f, "{}", e),
+            ReadError::Io(e) => write!(f, "{e}"),
             ReadError::MissingRecipientsFile(filename) => wfl!(
                 f,
                 "err-read-missing-recipients-file",
@@ -91,7 +91,7 @@ impl fmt::Display for ReadError {
             ),
             ReadError::MultipleStdin => wfl!(f, "err-read-multiple-stdin"),
             #[cfg(feature = "plugin")]
-            ReadError::PluginResolve(e) => write!(f, "{}", e),
+            ReadError::PluginResolve(e) => write!(f, "{e}"),
             #[cfg(feature = "ssh")]
             ReadError::RsaModulusTooLarge => {
                 wfl!(f, "err-read-rsa-modulus-too-large", max_size = 4096)

--- a/age/src/cli_common/file_io.rs
+++ b/age/src/cli_common/file_io.rs
@@ -308,7 +308,7 @@ impl LazyFile {
             .as_mut()
             .unwrap()
             .as_mut()
-            .map_err(|e| io::Error::new(e.kind(), format!("Failed to open file '{}'", filename)))
+            .map_err(|e| io::Error::new(e.kind(), format!("Failed to open file '{filename}'")))
     }
 }
 
@@ -395,10 +395,7 @@ impl OutputWriter {
         } else if is_tty {
             if let OutputFormat::Binary = format {
                 // If output == Some("-") then this error is skipped.
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    FileError::DenyBinaryOutput,
-                ));
+                return Err(io::Error::other(FileError::DenyBinaryOutput));
             }
         }
 

--- a/age/src/error.rs
+++ b/age/src/error.rs
@@ -157,13 +157,13 @@ impl fmt::Display for PluginError {
                 metadata,
                 message,
             } => {
-                write!(f, "({}", kind)?;
+                write!(f, "({kind}")?;
                 for d in metadata {
-                    write!(f, " {}", d)?;
+                    write!(f, " {d}")?;
                 }
                 write!(f, ")")?;
                 if !message.is_empty() {
-                    write!(f, " {}", message)?;
+                    write!(f, " {message}")?;
                 }
                 Ok(())
             }
@@ -286,11 +286,11 @@ impl fmt::Display for EncryptError {
             #[cfg(feature = "plugin")]
             EncryptError::Plugin(errors) => match &errors[..] {
                 [] => unreachable!(),
-                [e] => write!(f, "{}", e),
+                [e] => write!(f, "{e}"),
                 _ => {
                     wlnfl!(f, "err-plugin-multiple")?;
                     for e in errors {
-                        writeln!(f, "- {}", e)?;
+                        writeln!(f, "- {e}")?;
                     }
                     Ok(())
                 }
@@ -388,11 +388,11 @@ impl fmt::Display for DecryptError {
             #[cfg(feature = "plugin")]
             DecryptError::Plugin(errors) => match &errors[..] {
                 [] => unreachable!(),
-                [e] => write!(f, "{}", e),
+                [e] => write!(f, "{e}"),
                 _ => {
                     wlnfl!(f, "err-plugin-multiple")?;
                     for e in errors {
-                        writeln!(f, "- {}", e)?;
+                        writeln!(f, "- {e}")?;
                     }
                     Ok(())
                 }

--- a/age/src/format.rs
+++ b/age/src/format.rs
@@ -221,12 +221,7 @@ impl Header {
     pub(crate) fn write<W: Write>(&self, mut output: W) -> io::Result<()> {
         cookie_factory::gen(write::header(self), &mut output)
             .map(|_| ())
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("failed to write header: {}", e),
-                )
-            })
+            .map_err(|e| io::Error::other(format!("failed to write header: {e}")))
     }
 
     #[cfg(feature = "async")]
@@ -235,12 +230,7 @@ impl Header {
         let mut buf = vec![];
         cookie_factory::gen(write::header(self), &mut buf)
             .map(|_| ())
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("failed to write header: {}", e),
-                )
-            })?;
+            .map_err(|e| io::Error::other(format!("failed to write header: {e}")))?;
 
         output.write_all(&buf).await
     }

--- a/age/src/identity.rs
+++ b/age/src/identity.rs
@@ -342,44 +342,44 @@ pub(crate) mod tests {
 
     #[test]
     fn secret_key_lf() {
-        valid_secret_key_encoding(&format!("{}\n", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("{TEST_SK}\n"), 1);
     }
 
     #[test]
     fn two_secret_keys_lf() {
-        valid_secret_key_encoding(&format!("{}\n{}", TEST_SK, TEST_SK), 2);
+        valid_secret_key_encoding(&format!("{TEST_SK}\n{TEST_SK}"), 2);
     }
 
     #[test]
     fn secret_key_with_comment_lf() {
-        valid_secret_key_encoding(&format!("# Foo bar baz\n{}", TEST_SK), 1);
-        valid_secret_key_encoding(&format!("{}\n# Foo bar baz", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("# Foo bar baz\n{TEST_SK}"), 1);
+        valid_secret_key_encoding(&format!("{TEST_SK}\n# Foo bar baz"), 1);
     }
 
     #[test]
     fn secret_key_with_empty_line_lf() {
-        valid_secret_key_encoding(&format!("\n\n{}", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("\n\n{TEST_SK}"), 1);
     }
 
     #[test]
     fn secret_key_crlf() {
-        valid_secret_key_encoding(&format!("{}\r\n", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("{TEST_SK}\r\n"), 1);
     }
 
     #[test]
     fn two_secret_keys_crlf() {
-        valid_secret_key_encoding(&format!("{}\r\n{}", TEST_SK, TEST_SK), 2);
+        valid_secret_key_encoding(&format!("{TEST_SK}\r\n{TEST_SK}"), 2);
     }
 
     #[test]
     fn secret_key_with_comment_crlf() {
-        valid_secret_key_encoding(&format!("# Foo bar baz\r\n{}", TEST_SK), 1);
-        valid_secret_key_encoding(&format!("{}\r\n# Foo bar baz", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("# Foo bar baz\r\n{TEST_SK}"), 1);
+        valid_secret_key_encoding(&format!("{TEST_SK}\r\n# Foo bar baz"), 1);
     }
 
     #[test]
     fn secret_key_with_empty_line_crlf() {
-        valid_secret_key_encoding(&format!("\r\n\r\n{}", TEST_SK), 1);
+        valid_secret_key_encoding(&format!("\r\n\r\n{TEST_SK}"), 1);
     }
 
     #[test]

--- a/age/src/native/tag.rs
+++ b/age/src/native/tag.rs
@@ -83,7 +83,7 @@ impl fmt::Display for Recipient {
 
 impl fmt::Debug for Recipient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/age/src/native/tagpq.rs
+++ b/age/src/native/tagpq.rs
@@ -83,7 +83,7 @@ impl fmt::Display for Recipient {
 
 impl fmt::Debug for Recipient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/age/src/native/tagpq/kem.rs
+++ b/age/src/native/tagpq/kem.rs
@@ -247,7 +247,7 @@ fn expand_key(
 
 fn p256_random_scalar(seed: &[u8; 128]) -> p256::SecretKey {
     for sk in seed.chunks_exact(32) {
-        if let Ok(sk) = p256::SecretKey::from_bytes(sk.try_into().expect("correct length")) {
+        if let Ok(sk) = p256::SecretKey::from_bytes(sk.into()) {
             return sk;
         }
     }

--- a/age/src/native/x25519.rs
+++ b/age/src/native/x25519.rs
@@ -190,7 +190,7 @@ impl fmt::Display for Recipient {
 
 impl fmt::Debug for Recipient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/age/src/plugin.rs
+++ b/age/src/plugin.rs
@@ -51,10 +51,13 @@ fn valid_plugin_name(plugin_name: &str) -> bool {
 }
 
 fn binary_name(plugin_name: &str) -> String {
-    format!("age-plugin-{}", plugin_name)
+    format!("age-plugin-{plugin_name}")
 }
 
-struct SlowPluginGuard(mpsc::Sender<()>);
+/// A guard that keeps the timer thread (started by [`SlowPluginGuard::new`])
+/// alive. The held [`mpsc::Sender`] is never read; it exists solely so that
+/// dropping the guard disconnects the channel, signalling the thread to stop.
+struct SlowPluginGuard(#[allow(dead_code)] mpsc::Sender<()>);
 
 impl SlowPluginGuard {
     /// Starts a thread to print out a progress message after 10 seconds if the plugin
@@ -202,7 +205,7 @@ impl Identity {
     pub fn default_for_plugin(plugin_name: &str) -> Result<Self, ResolveError> {
         if valid_plugin_name(plugin_name) {
             Ok(bech32_encode(
-                Hrp::parse_unchecked(&format!("{}{}-", PLUGIN_IDENTITY_PREFIX, plugin_name)),
+                Hrp::parse_unchecked(&format!("{PLUGIN_IDENTITY_PREFIX}{plugin_name}-")),
                 &[],
             )
             .to_uppercase()
@@ -240,7 +243,7 @@ impl Plugin {
             // the Windows host are available to us, but `which` only trials PATHEXT
             // extensions automatically when compiled for Windows.
             if wsl::is_wsl() {
-                which::which(format!("{}.exe", binary_name)).map_err(|_| e)
+                which::which(format!("{binary_name}.exe")).map_err(|_| e)
             } else {
                 Err(e)
             }
@@ -333,10 +336,7 @@ fn handle_confirm<R: io::Read, W: io::Write, C: Callbacks>(
             errors.push(PluginError::Other {
                 kind: "internal".to_owned(),
                 metadata: vec![],
-                message: format!(
-                    "{} command must have at least one metadata argument",
-                    CMD_CONFIRM
-                ),
+                message: format!("{CMD_CONFIRM} command must have at least one metadata argument"),
             });
             return reply.fail();
         }
@@ -345,8 +345,7 @@ fn handle_confirm<R: io::Read, W: io::Write, C: Callbacks>(
                 kind: "internal".to_owned(),
                 metadata: vec![],
                 message: format!(
-                    "The first two metadata arguments to the {} command must be Base64-encoded",
-                    CMD_CONFIRM
+                    "The first two metadata arguments to the {CMD_CONFIRM} command must be Base64-encoded"
                 ),
             });
             return reply.fail();
@@ -492,8 +491,7 @@ impl<C: Callbacks> crate::Recipient for RecipientPluginV1<C> {
                             kind: "internal".to_owned(),
                             metadata: vec![],
                             message: format!(
-                                "{} command must have at least two metadata arguments",
-                                CMD_RECIPIENT_STANZA
+                                "{CMD_RECIPIENT_STANZA} command must have at least two metadata arguments"
                             ),
                         });
                     }
@@ -510,8 +508,7 @@ impl<C: Callbacks> crate::Recipient for RecipientPluginV1<C> {
                                 kind: "internal".to_owned(),
                                 metadata: vec![],
                                 message: format!(
-                                    "{} command must not contain duplicate labels",
-                                    CMD_LABELS
+                                    "{CMD_LABELS} command must not contain duplicate labels"
                                 ),
                             });
                         }
@@ -520,8 +517,7 @@ impl<C: Callbacks> crate::Recipient for RecipientPluginV1<C> {
                             kind: "internal".to_owned(),
                             metadata: vec![],
                             message: format!(
-                                "{} command must not be sent more than once",
-                                CMD_LABELS
+                                "{CMD_LABELS} command must not be sent more than once"
                             ),
                         });
                     }
@@ -811,10 +807,7 @@ mod tests {
     #[test]
     fn recipient_rejects_invalid_chars() {
         let invalid_recipient = bech32_encode(
-            Hrp::parse_unchecked(&format!(
-                "{}{}",
-                PLUGIN_RECIPIENT_PREFIX, INVALID_PLUGIN_NAME
-            )),
+            Hrp::parse_unchecked(&format!("{PLUGIN_RECIPIENT_PREFIX}{INVALID_PLUGIN_NAME}")),
             &[],
         );
         assert!(invalid_recipient.parse::<Recipient>().is_err());
@@ -823,7 +816,7 @@ mod tests {
     #[test]
     fn identity_rejects_empty_name() {
         let invalid_identity = bech32_encode(
-            Hrp::parse_unchecked(&format!("{}-", PLUGIN_IDENTITY_PREFIX)),
+            Hrp::parse_unchecked(&format!("{PLUGIN_IDENTITY_PREFIX}-")),
             &[],
         )
         .to_uppercase();
@@ -833,10 +826,7 @@ mod tests {
     #[test]
     fn identity_rejects_invalid_chars() {
         let invalid_identity = bech32_encode(
-            Hrp::parse_unchecked(&format!(
-                "{}{}-",
-                PLUGIN_IDENTITY_PREFIX, INVALID_PLUGIN_NAME
-            )),
+            Hrp::parse_unchecked(&format!("{PLUGIN_IDENTITY_PREFIX}{INVALID_PLUGIN_NAME}-")),
             &[],
         )
         .to_uppercase();

--- a/age/src/primitives/armor.rs
+++ b/age/src/primitives/armor.rs
@@ -1397,13 +1397,13 @@ mod tests {
                     match w.as_mut().poll_write(&mut cx, tmp) {
                         Poll::Ready(Ok(0)) => break,
                         Poll::Ready(Ok(written)) => tmp = &tmp[written..],
-                        Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                        Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                         Poll::Pending => panic!("Unexpected Pending"),
                     }
                 }
                 match w.as_mut().poll_close(&mut cx) {
                     Poll::Ready(Ok(())) => (),
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }
@@ -1420,7 +1420,7 @@ mod tests {
                     match input.as_mut().poll_read(&mut cx, &mut tmp) {
                         Poll::Ready(Ok(0)) => break,
                         Poll::Ready(Ok(read)) => buf.extend_from_slice(&tmp[..read]),
-                        Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                        Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                         Poll::Pending => panic!("Unexpected Pending"),
                     }
                 }
@@ -1549,13 +1549,13 @@ mod tests {
                 match w.as_mut().poll_write(&mut cx, tmp) {
                     Poll::Ready(Ok(0)) => break,
                     Poll::Ready(Ok(written)) => tmp = &tmp[written..],
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }
             match w.as_mut().poll_close(&mut cx) {
                 Poll::Ready(Ok(())) => (),
-                Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                 Poll::Pending => panic!("Unexpected Pending"),
             }
         }
@@ -1580,7 +1580,7 @@ mod tests {
                 match input.as_mut().poll_read(&mut cx, &mut tmp) {
                     Poll::Ready(Ok(0)) => break,
                     Poll::Ready(Ok(read)) => buf_async.extend_from_slice(&tmp[..read]),
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }

--- a/age/src/primitives/stream.rs
+++ b/age/src/primitives/stream.rs
@@ -562,8 +562,7 @@ impl<R: Read + Seek> StreamReader<R> {
                 let ct_len = ct_end - ct_start;
 
                 // Use ceiling division to determine the number of chunks.
-                let num_chunks =
-                    (ct_len + (ENCRYPTED_CHUNK_SIZE as u64 - 1)) / ENCRYPTED_CHUNK_SIZE as u64;
+                let num_chunks = ct_len.div_ceil(ENCRYPTED_CHUNK_SIZE as u64);
 
                 // If we have no ciphertext data then there is no last chunk, which is
                 // invalid.
@@ -812,13 +811,13 @@ mod tests {
                 match w.as_mut().poll_write(&mut cx, tmp) {
                     Poll::Ready(Ok(0)) => break,
                     Poll::Ready(Ok(written)) => tmp = &tmp[written..],
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }
             match w.as_mut().poll_close(&mut cx) {
                 Poll::Ready(Ok(())) => (),
-                Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                 Poll::Pending => panic!("Unexpected Pending"),
             }
         };
@@ -835,7 +834,7 @@ mod tests {
                 match r.as_mut().poll_read(&mut cx, &mut tmp) {
                     Poll::Ready(Ok(0)) => break buf,
                     Poll::Ready(Ok(read)) => buf.extend_from_slice(&tmp[..read]),
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }
@@ -883,7 +882,7 @@ mod tests {
 
         match result {
             Ok(written) => assert_eq!(written, data.len() as u64),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
         }
 
         let decrypted = {
@@ -895,7 +894,7 @@ mod tests {
 
             match result {
                 Ok(written) => assert_eq!(written, data.len() as u64),
-                Err(e) => panic!("Unexpected error: {}", e),
+                Err(e) => panic!("Unexpected error: {e}"),
             }
 
             buf

--- a/age/src/protocol.rs
+++ b/age/src/protocol.rs
@@ -390,7 +390,7 @@ mod tests {
 
                 match f.as_mut().poll(&mut cx) {
                     Poll::Ready(Ok(w)) => w,
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             };
@@ -401,13 +401,13 @@ mod tests {
                 match w.as_mut().poll_write(&mut cx, tmp) {
                     Poll::Ready(Ok(0)) => break,
                     Poll::Ready(Ok(written)) => tmp = &tmp[written..],
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }
             match w.as_mut().poll_close(&mut cx) {
                 Poll::Ready(Ok(())) => (),
-                Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                 Poll::Pending => panic!("Unexpected Pending"),
             }
         }
@@ -418,7 +418,7 @@ mod tests {
 
             match f.as_mut().poll(&mut cx) {
                 Poll::Ready(Ok(w)) => w,
-                Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                 Poll::Pending => panic!("Unexpected Pending"),
             }
         };
@@ -433,7 +433,7 @@ mod tests {
                 match r.as_mut().poll_read(&mut cx, &mut tmp) {
                     Poll::Ready(Ok(0)) => break buf,
                     Poll::Ready(Ok(read)) => buf.extend_from_slice(&tmp[..read]),
-                    Poll::Ready(Err(e)) => panic!("Unexpected error: {}", e),
+                    Poll::Ready(Err(e)) => panic!("Unexpected error: {e}"),
                     Poll::Pending => panic!("Unexpected Pending"),
                 }
             }

--- a/age/src/ssh/identity.rs
+++ b/age/src/ssh/identity.rs
@@ -63,7 +63,7 @@ impl UnencryptedKey {
     pub(crate) fn unwrap_stanza(&self, stanza: &Stanza) -> Option<Result<FileKey, DecryptError>> {
         match (self, stanza.tag.as_str()) {
             (UnencryptedKey::SshRsa(ssh_key, sk), SSH_RSA_RECIPIENT_TAG) => {
-                let tag = base64_arg::<_, TAG_LEN_BYTES, 6>(stanza.args.get(0)?)?;
+                let tag = base64_arg::<_, TAG_LEN_BYTES, 6>(stanza.args.first()?)?;
                 if ssh_tag(ssh_key) != tag {
                     return None;
                 }
@@ -95,7 +95,7 @@ impl UnencryptedKey {
                 )
             }
             (UnencryptedKey::SshEd25519(ssh_key, privkey), SSH_ED25519_RECIPIENT_TAG) => {
-                let tag = base64_arg::<_, TAG_LEN_BYTES, 6>(stanza.args.get(0)?)?;
+                let tag = base64_arg::<_, TAG_LEN_BYTES, 6>(stanza.args.first()?)?;
                 if ssh_tag(ssh_key) != tag {
                     return None;
                 }
@@ -189,8 +189,7 @@ impl UnsupportedKey {
             )?,
             UnsupportedKey::EncryptedSsh(cipher) => {
                 let new_issue = format!(
-                    "https://github.com/str4d/rage/issues/new?title=Support%20OpenSSH%20key%20encryption%20cipher%20{}",
-                    cipher,
+                    "https://github.com/str4d/rage/issues/new?title=Support%20OpenSSH%20key%20encryption%20cipher%20{cipher}",
                 );
                 wfl!(
                     f,
@@ -548,14 +547,14 @@ AwQFBg==
     #[test]
     fn ssh_ed25519_round_trip() {
         for (kind, sk) in TEST_SSH_ED25519_SK_LIST {
-            eprintln!("Testing cipher '{}'", kind);
+            eprintln!("Testing cipher '{kind}'");
             let buf = BufReader::new(sk.as_bytes());
             let identity = Identity::from_buffer(buf, None).unwrap();
             match (*kind, &identity) {
                 ("none", Identity::Unencrypted(_)) => (),
                 ("none", _) => panic!("key should be unencrypted"),
                 (_, Identity::Encrypted(_)) => (),
-                (_, Identity::Unsupported(_)) => panic!("{} cipher is unsupported", kind),
+                (_, Identity::Unsupported(_)) => panic!("{kind} cipher is unsupported"),
                 (_, _) => panic!("key should be encrypted"),
             };
             let identity = identity.with_callbacks(TestPassphrase("passphrase"));

--- a/age/src/util.rs
+++ b/age/src/util.rs
@@ -69,7 +69,7 @@ pub(crate) mod read {
         use nom::bytes::streaming::take;
 
         // Unpadded encoded length
-        let encoded_count = ((4 * count) + 2) / 3;
+        let encoded_count = (4 * count).div_ceil(3);
 
         move |input: &str| {
             let (i, data) = take(encoded_count)(input)?;

--- a/age/tests/test_vectors.rs
+++ b/age/tests/test_vectors.rs
@@ -55,8 +55,8 @@ fn age_test_vectors() -> Result<(), Box<dyn std::error::Error>> {
                 let mut buf = vec![];
                 r.read_to_end(&mut buf)?;
             }
-            (Ok(_), true) => panic!("Test vector {} did not fail as expected", name),
-            (Err(e), false) => panic!("Test vector {} failed unexpectedly: {:?}", name, e),
+            (Ok(_), true) => panic!("Test vector {name} did not fail as expected"),
+            (Err(e), false) => panic!("Test vector {name} failed unexpectedly: {e:?}"),
             (Err(_), true) => (),
         }
     }

--- a/rage/CHANGELOG.md
+++ b/rage/CHANGELOG.md
@@ -17,7 +17,7 @@ to 1.0.0 are beta releases.
   - `age1tagpq1..`
 
 ### Changed
-- MSRV is now 1.74.0.
+- MSRV is now 1.88.0.
 
 ## [0.11.2] - 2026-04-22
 ### Changed

--- a/rage/build.rs
+++ b/rage/build.rs
@@ -203,7 +203,7 @@ impl Cli {
             cmd: Command,
             custom: impl FnOnce(&Man, &mut GzEncoder<fs::File>) -> io::Result<()>,
         ) -> io::Result<()> {
-            let file = fs::File::create(out_dir.join(format!("{}.1.gz", name)))?;
+            let file = fs::File::create(out_dir.join(format!("{name}.1.gz")))?;
             let mut w = GzEncoder::new(file, Compression::best());
 
             let man = Man::new(cmd);

--- a/rage/src/bin/rage-mount/main.rs
+++ b/rage/src/bin/rage-mount/main.rs
@@ -92,13 +92,13 @@ impl fmt::Debug for Error {
         match self {
             Error::Age(e) => match e {
                 age::DecryptError::ExcessiveWork { required, .. } => {
-                    writeln!(f, "{}", e)?;
+                    writeln!(f, "{e}")?;
                     wfl!(f, "rec-dec-excessive-work", wf = required)
                 }
-                _ => write!(f, "{}", e),
+                _ => write!(f, "{e}"),
             },
-            Error::IdentityRead(e) => write!(f, "{}", e),
-            Error::Io(e) => write!(f, "{}", e),
+            Error::IdentityRead(e) => write!(f, "{e}"),
+            Error::Io(e) => write!(f, "{e}"),
             Error::MissingFilename => wfl!(f, "err-mnt-missing-filename"),
             Error::MissingIdentities => {
                 wlnfl!(f, "err-dec-missing-identities")?;

--- a/rage/src/bin/rage-mount/tar.rs
+++ b/rage/src/bin/rage-mount/tar.rs
@@ -25,8 +25,7 @@ fn tar_to_filetype<R: Read>(entry: &Entry<R>) -> Option<FileType> {
 }
 
 fn tar_to_fuse<R: Read>(entry: &Entry<R>) -> io::Result<FileAttr> {
-    let kind = tar_to_filetype(entry)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Unsupported filetype"))?;
+    let kind = tar_to_filetype(entry).ok_or_else(|| io::Error::other("Unsupported filetype"))?;
     let perm = (entry.header().mode()? & 0o7777) as u16;
 
     let mtime = SystemTime::UNIX_EPOCH + Duration::new(entry.header().mtime()?, 0);

--- a/rage/src/bin/rage-mount/zip.rs
+++ b/rage/src/bin/rage-mount/zip.rs
@@ -96,16 +96,13 @@ impl AgeZipFs {
         stream: StreamReader<ArmoredReader<BufReader<File>>>,
         destroy_tx: mpsc::SyncSender<()>,
     ) -> io::Result<Self> {
-        let mut archive =
-            ZipArchive::new(stream).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let mut archive = ZipArchive::new(stream).map_err(io::Error::other)?;
 
         // Build a directory listing for the archive
         let mut dir_map: HashMap<PathBuf, Vec<DirectoryEntry>> = HashMap::new();
         dir_map.insert(PathBuf::new(), vec![]); // the root
         for i in 0..archive.len() {
-            let zf = archive
-                .by_index(i)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let zf = archive.by_index(i).map_err(io::Error::other)?;
             if let Some(path) = zf.enclosed_name() {
                 add_dir_to_map(&mut dir_map, &path, zipfile_to_filetype(&zf));
             }

--- a/rage/src/bin/rage/cli.rs
+++ b/rage/src/bin/rage/cli.rs
@@ -19,7 +19,7 @@ fn binary_name(suffix: Option<&str>) -> String {
                 .extension()
                 .map(|extension| format!(".{}", extension.to_string_lossy()))
                 .unwrap_or_default();
-            format!("{}{}{}", stem, suffix, extension)
+            format!("{stem}{suffix}{extension}")
         } else {
             path.file_name()
                 .expect("is not directory")
@@ -58,16 +58,11 @@ pub(crate) fn after_help_content(keygen_name: &str) -> String {
 fn after_help() -> String {
     let keygen_name = binary_name(Some("-keygen"));
     let binary_name = binary_name(None);
-    let example_a = format!("$ {} -o key.txt", keygen_name);
+    let example_a = format!("$ {keygen_name} -o key.txt");
     let example_a_output = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p";
-    let example_b = format!(
-        "$ tar cvz ~/data | {} -r {} > data.tar.gz.age",
-        binary_name, example_a_output,
-    );
-    let example_c = format!(
-        "$ {} -d -i key.txt -o data.tar.gz data.tar.gz.age",
-        binary_name,
-    );
+    let example_b =
+        format!("$ tar cvz ~/data | {binary_name} -r {example_a_output} > data.tar.gz.age",);
+    let example_c = format!("$ {binary_name} -d -i key.txt -o data.tar.gz data.tar.gz.age",);
 
     format!(
         "{}\n\n{}",

--- a/rage/src/bin/rage/error.rs
+++ b/rage/src/bin/rage/error.rs
@@ -63,10 +63,10 @@ impl fmt::Display for EncryptError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EncryptError::Age(e @ age::EncryptError::MissingRecipients) => {
-                writeln!(f, "{}", e)?;
+                writeln!(f, "{e}")?;
                 wfl!(f, "rec-enc-missing-recipients")
             }
-            EncryptError::Age(e) => write!(f, "{}", e),
+            EncryptError::Age(e) => write!(f, "{e}"),
             EncryptError::BrokenPipe { is_stdout, source } => {
                 if *is_stdout {
                     wlnfl!(f, "err-enc-broken-stdout", err = source.to_string())?;
@@ -75,8 +75,8 @@ impl fmt::Display for EncryptError {
                     wfl!(f, "err-enc-broken-file", err = source.to_string())
                 }
             }
-            EncryptError::IdentityRead(e) => write!(f, "{}", e),
-            EncryptError::Io(e) => write!(f, "{}", e),
+            EncryptError::IdentityRead(e) => write!(f, "{e}"),
+            EncryptError::Io(e) => write!(f, "{e}"),
             EncryptError::MixedIdentityAndPassphrase => {
                 wfl!(f, "err-enc-mixed-identity-passphrase")
             }
@@ -157,17 +157,17 @@ impl fmt::Display for DecryptError {
         match self {
             DecryptError::Age(e) => match e {
                 age::DecryptError::ExcessiveWork { required, .. } => {
-                    writeln!(f, "{}", e)?;
+                    writeln!(f, "{e}")?;
                     wfl!(f, "rec-dec-excessive-work", wf = required)
                 }
-                _ => write!(f, "{}", e),
+                _ => write!(f, "{e}"),
             },
             DecryptError::ArmorFlag => {
                 wlnfl!(f, "err-dec-armor-flag")?;
                 wfl!(f, "rec-dec-armor-flag")
             }
-            DecryptError::IdentityRead(e) => write!(f, "{}", e),
-            DecryptError::Io(e) => write!(f, "{}", e),
+            DecryptError::IdentityRead(e) => write!(f, "{e}"),
+            DecryptError::Io(e) => write!(f, "{e}"),
             DecryptError::MissingIdentities { stdin_identity } => {
                 wlnfl!(f, "err-dec-missing-identities")?;
                 if *stdin_identity {
@@ -228,8 +228,8 @@ impl From<EncryptError> for Error {
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Decryption(e) => writeln!(f, "{}", e)?,
-            Error::Encryption(e) => writeln!(f, "{}", e)?,
+            Error::Decryption(e) => writeln!(f, "{e}")?,
+            Error::Encryption(e) => writeln!(f, "{e}")?,
             Error::IdentityFlagAmbiguous => wlnfl!(f, "err-identity-ambiguous")?,
             Error::MixedEncryptAndDecrypt => wlnfl!(f, "err-mixed-encrypt-decrypt")?,
             Error::SameInputAndOutput(filename) => {

--- a/rage/src/bin/rage/main.rs
+++ b/rage/src/bin/rage/main.rs
@@ -162,10 +162,7 @@ fn encrypt(opts: AgeOptions) -> Result<(), error::EncryptError> {
             }
             Err(pinentry::Error::Gpg(e)) => {
                 // Pretend it is an I/O error
-                return Err(error::EncryptError::Io(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("{}", e),
-                )));
+                return Err(error::EncryptError::Io(io::Error::other(format!("{e}"))));
             }
             Err(pinentry::Error::Io(e)) => return Err(error::EncryptError::Io(e)),
         }
@@ -338,10 +335,7 @@ fn decrypt(opts: AgeOptions) -> Result<(), error::DecryptError> {
             }
             Err(pinentry::Error::Gpg(e)) => {
                 // Pretend it is an I/O error
-                Err(error::DecryptError::Io(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("{}", e),
-                )))
+                Err(error::DecryptError::Io(io::Error::other(format!("{e}"))))
             }
             Err(pinentry::Error::Io(e)) => Err(error::DecryptError::Io(e)),
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Moves the minimum supported Rust version to 1.88.

## Changes

- Set the workspace `rust-version`, the pinned `rust-toolchain.toml`, the
  README install table, and the per-crate CHANGELOG entries to 1.88.0.
- Enable the `unexpected_cfgs` workspace lint that was previously gated on
  MSRV 1.80.
- Fix the clippy lints that the 1.88 toolchain now enforces under
  `-D warnings`:
  - `uninlined_format_args`: inline the format arguments.
  - `io_other_error`: use `io::Error::other` (stable since 1.74).
  - `dead_code`: annotate the `SlowPluginGuard` sender, which is held only
    so that dropping the guard signals the timer thread to stop.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` and
`cargo fmt --check` are clean under the pinned 1.88.0 toolchain. The
`mount`-feature fixes (`rage-mount`) could not be compiled locally (they
require FUSE) and are covered by CI's `--all-features` clippy job.