### PR TITLE
docs: clarify PIV token support wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ age was designed by [@Benjojo](https://benjojo.co.uk/) and
 The reference interoperable Go implementation is available at
 [filippo.io/age](https://filippo.io/age).
 
-Hardware PIV tokens such as YubiKeys are supported through the
+Hardware PIV tokens with compatible keys, such as YubiKeys, are supported through the
 [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) plugin.
 
 For more plugins, implementations, tools, and integrations, check out the


### PR DESCRIPTION
## Summary

Clarifies the README wording for hardware PIV token support to avoid the impression that all PIV tokens are broadly supported.

**Before:**
> Hardware PIV tokens such as YubiKeys are supported through the [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) plugin.

**After:**
> Hardware PIV tokens with compatible keys, such as YubiKeys, are supported through the [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) plugin.

## Rationale

As discussed in #541, the original wording can be read as implying that hardware PIV tokens generally (e.g. YubiKeys) are supported. In practice, `age-plugin-yubikey` only supports PIV tokens with an ECDSA P-256 key and certificate in one of the 20 "retired" PIV slots (see the [age-plugin-yubikey README](https://github.com/str4d/age-plugin-yubikey#manual-setup-and-technical-details)).

Adding "with compatible keys" aligns the `rage` README with the `age-plugin-yubikey` README's own scope description, while preserving the existing terminology ("PIV tokens" per NIST SP 800-57) that the maintainer noted is correct.

Addresses #541.

---

**AI usage disclosure:** An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.