### PR TITLE
Cargo.toml: cookie-factory: disable default features, use "std" only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,9 +653,6 @@ name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
-dependencies = [
- "futures",
-]
 
 [[package]]
 name = "core-foundation-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ rand = "0.10"
 bech32 = "0.11"
 
 # Parsing
-cookie-factory = "0.3.1"
+cookie-factory = { version = "0.3.1", default-features = false, features = [ "std" ] }
 nom = { version = "8", default-features = false, features = ["alloc"] }
 
 # Secret management


### PR DESCRIPTION
The features ["std", "async"] are enabled by default, but inside the crates async code of cookie-factory is never used.


Here's the diff when running `cargo tree`:

```diff
65,89d64
< │   │   └── futures v0.3.32
< │   │       ├── futures-channel v0.3.32
< │   │       │   ├── futures-core v0.3.32
< │   │       │   └── futures-sink v0.3.32
< │   │       ├── futures-core v0.3.32
< │   │       ├── futures-executor v0.3.32
< │   │       │   ├── futures-core v0.3.32
< │   │       │   ├── futures-task v0.3.32
< │   │       │   └── futures-util v0.3.32
< │   │       │       ├── futures-channel v0.3.32 (*)
< │   │       │       ├── futures-core v0.3.32
< │   │       │       ├── futures-io v0.3.32
< │   │       │       ├── futures-macro v0.3.32 (proc-macro)
< │   │       │       │   ├── proc-macro2 v1.0.106 (*)
< │   │       │       │   ├── quote v1.0.46 (*)
< │   │       │       │   └── syn v2.0.118 (*)
< │   │       │       ├── futures-sink v0.3.32
< │   │       │       ├── futures-task v0.3.32
< │   │       │       ├── memchr v2.8.3
< │   │       │       ├── pin-project-lite v0.2.17
< │   │       │       └── slab v0.4.12
< │   │       ├── futures-io v0.3.32
< │   │       ├── futures-sink v0.3.32
< │   │       ├── futures-task v0.3.32
< │   │       └── futures-util v0.3.32 (*)
253c228
< ├── cookie-factory v0.3.3 (*)
---
> ├── cookie-factory v0.3.3
526c501,510
< │   ├── futures-executor v0.3.32 (*)
---
> │   ├── futures-executor v0.3.32
> │   │   ├── futures-core v0.3.32
> │   │   ├── futures-task v0.3.32
> │   │   └── futures-util v0.3.32
> │   │       ├── futures-core v0.3.32
> │   │       ├── futures-io v0.3.32
> │   │       ├── futures-task v0.3.32
> │   │       ├── memchr v2.8.3
> │   │       ├── pin-project-lite v0.2.17
> │   │       └── slab v0.4.12
528c512,515
< │   ├── futures-macro v0.3.32 (proc-macro) (*)
---
> │   ├── futures-macro v0.3.32 (proc-macro)
> │   │   ├── proc-macro2 v1.0.106 (*)
> │   │   ├── quote v1.0.46 (*)
> │   │   └── syn v2.0.118 (*)
```

The big red block is for the usage of cookie-factory in `age-core` crate.

The green blocks is because `futures-test` (used as a dev-dependency in the `age` crate) uses those crates.